### PR TITLE
Flathub-based Gaia downloader for faint catalogs (closes #30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## Unreleased
+
+### New features
+
+- **Faint-magnitude Gaia downloads via Flatiron flathub (issue #30).**
+  New script `scripts/download_gaia_flatiron.py` queries the Flatiron
+  Institute's [flathub](https://flathub.flatironinstitute.org/) service
+  to pull Gaia DR3 past G ≈ 11.5. ESA TAP's anonymous async output is
+  capped at a hard 3,000,000 rows per job (server-side, advertised in
+  `/capabilities`), so the existing `scripts/download_gaia_catalog.py`
+  effectively tops out at G ≈ 11.5 (G < 12 is 3.09M rows, just over the
+  cap). flathub has no such cap and serves the full Gaia DR3 catalog.
+  Both scripts share the Hipparcos-2 bright-star merge and produce
+  byte-compatible `.bin` / `.csv` output, so the new downloader is a
+  drop-in when fainter limits are needed. flathub is not on PyPI —
+  install from the [upstream repo](https://github.com/flatironinstitute/flathub/tree/prod/py).
+
+### Other
+
+- New [Star Catalog](https://tetra3rs.dev/getting-started/catalog/)
+  documentation page covering the pre-built download, both `scripts/`
+  downloaders (including the ESA TAP 3M-row cap and account-registration
+  workaround), the Hipparcos bright-star merge, and the on-disk format.
+  Signposted from the README, the installation page, and the `tetra3`
+  crate top-level doc.
+
 ## 0.7.1
 
 ### New features

--- a/README.md
+++ b/README.md
@@ -94,14 +94,19 @@ tetra3rs uses a merged Gaia DR3 + Hipparcos catalog. The merged catalog uses Gai
 
 **Python:** The catalog is bundled in the [`gaia-catalog`](https://pypi.org/project/gaia-catalog/) package (installed automatically with `tetra3rs`). No manual download needed — just call `generate_from_gaia()` with no arguments.
 
-**Rust:** Download the pre-built binary catalog:
+**Rust:** Download the pre-built binary catalog (G < 10, ~17 MB):
 
 ```sh
 mkdir -p data
 curl -o data/gaia_merged.bin "https://storage.googleapis.com/tetra3rs-testvecs/gaia_merged.bin"
 ```
 
-Or generate your own with a custom magnitude limit using `scripts/download_gaia_catalog.py`.
+Or generate your own with a custom magnitude limit. Two scripts live in `scripts/`:
+
+- `download_gaia_catalog.py` — ESA Gaia Archive TAP server. Canonical Gaia source, but the server enforces a hard 3,000,000-row output limit per async job for anonymous users, so bulk queries top out at G ≈ 11.5.
+- `download_gaia_flatiron.py` — Flatiron Institute's [flathub](https://github.com/flatironinstitute/flathub) service. Serves the full Gaia DR3 catalog without the faint-end cap; use this if you need G > 11.5. flathub is not on PyPI — install it from the upstream repo.
+
+Both produce byte-compatible output and share the Hipparcos bright-star merge. See the [Star Catalog](https://tetra3rs.dev/getting-started/catalog/) docs page for setup, CLI flags, and the on-disk format.
 
 ### Example
 
@@ -285,10 +290,6 @@ The test suite includes:
 ```sh
 cargo test --test tess_solve_test --features image -- --nocapture
 ```
-
-## Roadmap (not in order)
-
-- **Deeper Gaia catalog** — support fainter limiting magnitudes for narrow-FOV cameras
 
 ## Credits
 

--- a/docs/getting-started/catalog.md
+++ b/docs/getting-started/catalog.md
@@ -1,0 +1,84 @@
+# Star Catalog
+
+tetra3rs solves against a merged **Gaia DR3 + Hipparcos** catalog. Gaia DR3 provides the bulk of stars; Hipparcos 2 fills in the few dozen brightest stars (G < 4) where Gaia saturates. Positions are stored at Gaia's reference epoch (J2016.0) and propagated to the observation epoch at solve time using per-star proper motion.
+
+The on-disk format is a compact little-endian binary (header `GDR3`, 36 bytes per star) used by both the Rust crate and the Python [`gaia-catalog`](https://pypi.org/project/gaia-catalog/) PyPI package. The same script can also write a CSV form.
+
+## Pre-built download
+
+The easiest path. A pre-built catalog with G < 10 (~17 MB, ~482k stars) is hosted on Google Cloud Storage:
+
+```sh
+mkdir -p data
+curl -o data/gaia_merged.bin "https://storage.googleapis.com/tetra3rs-testvecs/gaia_merged.bin"
+```
+
+Python users get the same file bundled in [`gaia-catalog`](https://pypi.org/project/gaia-catalog/), which is installed automatically with `tetra3rs` — no curl needed.
+
+## Generate your own
+
+If you need a different magnitude limit (e.g. fainter stars for narrow-FOV cameras) or want to regenerate at a more recent reference epoch, two download scripts live in `scripts/`:
+
+| Script | Backend | Practical mag limit | Setup |
+|---|---|---|---|
+| `download_gaia_catalog.py` | ESA Gaia Archive TAP server | G ≲ 11.5 (3M-row hard cap) | `pip install astroquery astropy` |
+| `download_gaia_flatiron.py` | [Flatiron Institute flathub](https://flathub.flatironinstitute.org/gaiadr3) | full Gaia DR3 | flathub from GitHub (see below) |
+
+Both scripts produce byte-compatible output and share the Hipparcos-2 bright-star merge — the flathub script imports the merge and writer functions from the ESA script.
+
+### ESA TAP (shallow catalogs)
+
+The canonical Gaia source. Default settings produce the same ~17 MB / ~482k-star catalog as the pre-built download:
+
+```sh
+pip install astroquery astropy
+bash scripts/download_hip2.sh
+python scripts/download_gaia_catalog.py --mag-limit 10.0 --output data/gaia_merged.bin
+```
+
+!!! warning "3-million-row cap"
+    The ESA TAP server advertises a **hard** output limit of 3,000,000 rows per async job for anonymous users (see `https://gea.esac.esa.int/tap-server/tap/capabilities`). Cumulative Gaia DR3 counts: G<10 ≈ 482k, G<11 ≈ 1.25M, G<12 ≈ 3.09M, G<13 ≈ 7.37M. So anonymous queries top out around **G ≈ 11.5**; fainter mags return a silently-truncated result. The script already uses `launch_job_async`, but the cap is server-side and `MAXREC` cannot raise it.
+
+    Workarounds: register for a free [Gaia archive account](https://www.cosmos.esa.int/web/gaia-users/register) (the per-job limit is higher for authenticated users), or use the flathub script below, which has no faint-end cap.
+
+### Flatiron flathub (faint catalogs)
+
+flathub hosts the full Gaia DR3 catalog and streams `.npy` payloads directly. It serves the same query as the ESA TAP backend without the faint-end cap.
+
+flathub is **not on PyPI**. Install from the upstream repo:
+
+```sh
+# one-shot from git
+pip install "flathub @ git+https://github.com/flatironinstitute/flathub.git@prod#subdirectory=py"
+
+# or clone + local install
+git clone https://github.com/flatironinstitute/flathub.git
+pip install ./flathub/py
+```
+
+You'll also need the Hipparcos 2 catalog for the bright-star merge:
+
+```sh
+bash scripts/download_hip2.sh
+```
+
+Then run the downloader:
+
+```sh
+pip install astropy scipy
+python scripts/download_gaia_flatiron.py --mag-limit 14.0 --output data/gaia_merged.bin
+```
+
+!!! note "NumPy 2.0 shim"
+    The flathub client currently calls `numpy.DataSource`, which NumPy 2.0 removed. The script shims that symbol back at import time, so no patch to flathub itself is needed.
+
+!!! warning "Large downloads"
+    A G < 14 catalog is ~17M stars, ~1 GB on disk; the response is served as a single streaming `.npy`. A corporate / filtering proxy may drop or truncate the connection — run the script on a direct connection if possible.
+
+## What's in the merged catalog
+
+Records, in either output format, carry: `source_id`, `ra`, `dec`, `phot_g_mean_mag`, `pmra`, `pmdec` (binary), plus `phot_bp_mean_mag`, `phot_rp_mean_mag`, `parallax` (CSV only).
+
+The Hipparcos merge propagates Hipparcos positions from the Hipparcos reference epoch (J1991.25) to the Gaia DR3 reference epoch (J2016.0) using each star's proper motion, then adds Hipparcos stars brighter than the bright-threshold (G ~ 4 by default) that have no Gaia counterpart within the match radius (5″ by default). Synthesized Hipparcos entries are stored with **negative** `source_id` values so they're distinguishable from real Gaia IDs. The relevant CLI flags are `--bright-threshold` and `--match-radius` (both scripts).
+
+See the docstrings in `scripts/download_gaia_catalog.py` and `scripts/download_gaia_flatiron.py` for the full option set and cross-match details.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -34,23 +34,9 @@ cargo add tetra3 --features image
 
 ## Star Catalog
 
-tetra3rs generates its pattern database from a merged Gaia DR3 + Hipparcos catalog (~482k stars to G-band magnitude 10). Gaia provides most stars; Hipparcos fills in the brightest stars (G < 4) where Gaia saturates.
+tetra3rs solves against a merged Gaia DR3 + Hipparcos catalog. Python users get this bundled automatically via the [`gaia-catalog`](https://pypi.org/project/gaia-catalog/) PyPI package — no setup needed. Rust users (and Python users who want a deeper magnitude limit) can download a pre-built binary or generate their own.
 
-**Python:** The catalog is bundled in the [`gaia-catalog`](https://pypi.org/project/gaia-catalog/) package, which is installed automatically with `tetra3rs`. No manual download needed — just call `generate_from_gaia()` with no arguments.
-
-**Rust:** Download the pre-built binary catalog (~17 MB):
-
-```sh
-mkdir -p data
-curl -o data/gaia_merged.bin "https://storage.googleapis.com/tetra3rs-testvecs/gaia_merged.bin"
-```
-
-Or generate your own with a custom magnitude limit:
-
-```sh
-pip install astroquery astropy
-python scripts/download_gaia_catalog.py --mag-limit 12.0 --output data/gaia_merged.bin
-```
+See [Star Catalog](catalog.md) for the pre-built download, custom-mag-limit scripts (ESA TAP up to G ≲ 10, Flatiron flathub for fainter), and the Hipparcos bright-star merge.
 
 !!! note
     The catalog is also downloaded automatically when running the Rust integration tests (`cargo test --features image`).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@ nav:
   - Home: index.md
   - Getting Started:
       - Installation: getting-started/installation.md
+      - Star Catalog: getting-started/catalog.md
       - Quick Start: getting-started/quickstart.md
   - Concepts:
       - Algorithm Overview: concepts/algorithm.md

--- a/scripts/download_gaia_flatiron.py
+++ b/scripts/download_gaia_flatiron.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""
+Download Gaia DR3 from the Flatiron Institute's flathub service.
+
+flathub (https://flathub.flatironinstitute.org) hosts the full Gaia DR3
+catalog and returns numpy arrays directly over HTTP. It is preferred over
+``download_gaia_catalog.py`` (which queries ESA's TAP server) when pulling
+faint stars in bulk: ESA's TAP service throttles / truncates large faint-end
+queries around G ~ 10, while flathub serves the same query without that cap.
+
+Output and Hipparcos gap-fill logic mirror ``download_gaia_catalog.py`` so
+the file is interchangeable with the sibling script:
+
+  - .bin  compact binary used by tetra3rs and the gaia-catalog Python package
+  - .csv  same columns as the sibling: source_id, ra, dec,
+          phot_g_mean_mag, phot_bp_mean_mag, phot_rp_mean_mag,
+          parallax, pmra, pmdec
+  - Bright Hipparcos 2 stars (estimated G < --bright-threshold) without a
+    Gaia counterpart are added with negative source_ids to fill Gaia's
+    bright-star saturation gap. Hipparcos positions are propagated from
+    J1991.25 to the Gaia DR3 epoch (J2016.0) before merging.
+
+Requirements:
+    numpy, astropy, scipy, requests (pip-installable).
+
+    flathub is not on PyPI — install it from the Flatiron Institute's repo
+    per the instructions at
+    https://github.com/flatironinstitute/flathub/tree/prod/py
+    (e.g. clone the repo and `pip install ./py`, or
+    `pip install "flathub @ git+https://github.com/flatironinstitute/flathub.git@prod#subdirectory=py"`).
+
+    The flathub client currently calls ``numpy.DataSource`` directly, which
+    NumPy 2.0 removed; this script shims that attribute back at import time
+    so no patch to flathub itself is needed.
+
+Usage:
+    python download_gaia_flatiron.py                                 # mag 10, binary
+    python download_gaia_flatiron.py --mag-limit 14 --output data/gaia14.bin
+    python download_gaia_flatiron.py --mag-limit 12 --output data/gaia12.csv
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+
+# Reuse Hipparcos loader, merge, and writers from the sibling script.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from download_gaia_catalog import (  # noqa: E402
+    GAIA_EPOCH,
+    load_hipparcos,
+    merge_catalogs,
+    propagate_hipparcos_to_epoch,
+    write_merged_binary,
+    write_merged_csv,
+)
+
+
+# Brightest Gaia DR3 source has phot_g_mean_mag ~ 1.732. flathub rejects
+# range queries that fall below the field's catalog-wide minimum, so we use
+# the exact lower bound advertised by the flathub schema.
+GAIA_G_MIN = 1.7316069602966309
+
+GAIA_FIELDS = [
+    "source_id",
+    "ra",
+    "dec",
+    "phot_g_mean_mag",
+    "phot_bp_mean_mag",
+    "phot_rp_mean_mag",
+    "parallax",
+    "pmra",
+    "pmdec",
+]
+
+
+def query_gaia_flathub(mag_limit: float) -> np.ndarray:
+    """Pull Gaia DR3 stars with G < mag_limit from flathub as a structured array."""
+    # flathub's client calls numpy.DataSource, which was removed in NumPy 2.0
+    # and is still reachable at numpy.lib.npyio.DataSource. Patch it back on
+    # before the import so the client can run unmodified.
+    if not hasattr(np, "DataSource"):
+        np.DataSource = np.lib.npyio.DataSource  # type: ignore[attr-defined]
+    import flathub
+
+    print(f"Querying flathub Gaia DR3 for stars with G < {mag_limit}...")
+    gaiadr3 = flathub.Catalog(
+        "gaiadr3", endpoint="https://flathub.flatironinstitute.org/api"
+    )
+    arr = gaiadr3.numpy(
+        fields=GAIA_FIELDS,
+        phot_g_mean_mag=(GAIA_G_MIN, mag_limit),
+    )
+    print(f"  Retrieved {len(arr)} Gaia stars")
+    return arr
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Download Gaia DR3 from flathub and merge with Hipparcos 2 bright stars"
+    )
+    parser.add_argument(
+        "--mag-limit",
+        type=float,
+        default=10.0,
+        help="Limiting G-band magnitude (default: 10.0)",
+    )
+    parser.add_argument(
+        "--bright-threshold",
+        type=float,
+        default=4.0,
+        help="G-mag threshold below which Hipparcos fills Gaia gaps (default: 4.0)",
+    )
+    parser.add_argument(
+        "--match-radius",
+        type=float,
+        default=5.0,
+        help="Cross-match radius in arcseconds (default: 5.0)",
+    )
+    parser.add_argument(
+        "--hip2",
+        type=str,
+        default="data/hip2.dat",
+        help="Path to hip2.dat file (default: data/hip2.dat)",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="data/gaia_merged.bin",
+        help="Output path; .bin for binary or .csv for CSV (default: data/gaia_merged.bin)",
+    )
+    args = parser.parse_args()
+
+    if not Path(args.hip2).exists():
+        print(f"Error: {args.hip2} not found. Run scripts/download_hip2.sh first.")
+        sys.exit(1)
+
+    gaia_table = query_gaia_flathub(args.mag_limit)
+
+    hip_table = load_hipparcos(args.hip2)
+    propagate_hipparcos_to_epoch(hip_table, GAIA_EPOCH)
+
+    hip_only, hip_gmag_only = merge_catalogs(
+        gaia_table,
+        hip_table,
+        bright_threshold=args.bright_threshold,
+        match_radius_arcsec=args.match_radius,
+    )
+
+    if args.output.endswith(".bin"):
+        write_merged_binary(gaia_table, hip_only, hip_gmag_only, args.output)
+    else:
+        write_merged_csv(gaia_table, hip_only, hip_gmag_only, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,23 @@
 //!   Images (~12° FOV, significant optical distortion). Multi-image calibration across
 //!   10 TESS sectors achieves sub-arcsec agreement with FITS WCS solutions
 //!
+//! ## Star catalog
+//!
+//! Solving requires a merged Gaia DR3 + Hipparcos catalog (`gaia_merged.bin`).
+//! A pre-built G < 10 catalog (~17 MB) is hosted at
+//! `https://storage.googleapis.com/tetra3rs-testvecs/gaia_merged.bin`. For
+//! custom magnitude limits, two scripts in `scripts/` produce byte-compatible
+//! output:
+//!
+//! - `download_gaia_catalog.py` — ESA TAP server (canonical Gaia source;
+//!   capped at G ≈ 11.5 by the server's 3,000,000-row anonymous output limit)
+//! - `download_gaia_flatiron.py` — Flatiron Institute flathub (full Gaia DR3,
+//!   needed for G > 11.5)
+//!
+//! Both merge in Hipparcos 2 bright stars (G < 4) where Gaia saturates. See
+//! the [Star Catalog docs](https://tetra3rs.dev/getting-started/catalog/) for
+//! setup details.
+//!
 //! ## Example
 //!
 //! ```no_run


### PR DESCRIPTION
## Summary

- New `scripts/download_gaia_flatiron.py` pulls Gaia DR3 from the Flatiron Institute's [flathub](https://flathub.flatironinstitute.org/) service, with no faint-end cap. Reuses the Hipparcos-2 bright-star merge and `.bin`/`.csv` writers from `scripts/download_gaia_catalog.py`, so output is byte-compatible.
- New `docs/getting-started/catalog.md` documents both downloaders, the ESA TAP 3,000,000-row hard cap (advertised in `/capabilities`), the registered-account workaround, the Hipparcos merge, and the on-disk format. Signposted from README, installation page, and `src/lib.rs` preamble.
- CHANGELOG entry under `## Unreleased` (no version bump — docs + script only).

## Why

`scripts/download_gaia_catalog.py` already uses `launch_job_async`, but ESA TAP enforces a **hard** 3,000,000-row output limit per anonymous async job:

```xml
<outputLimit>
    <default unit="row">3000000</default>
    <hard unit="row">3000000</hard>
</outputLimit>
```

`MAXREC` cannot raise a `hard` cap. Cumulative Gaia DR3 counts: G<10 ≈ 482k, G<11 ≈ 1.25M, G<12 ≈ 3.09M, G<13 ≈ 7.37M — so anonymous queries effectively top out at **G ≈ 11.5**. flathub serves the full Gaia DR3 catalog with no such cap (verified ~17M rows / ~1 GB streamed at G < 14).

## Test plan

- [x] Small end-to-end run: `python scripts/download_gaia_flatiron.py --mag-limit 5.0 --output /tmp/test.bin --hip2 data/hip2.dat` → 2168 Gaia + 74 Hipparcos gap-fill stars, binary readback confirms `GDR3`+v1 header and 36-byte records. Brightest entries (Sirius, Canopus, Vega, etc.) correctly sourced from Hipparcos.
- [x] `cargo doc --no-deps` builds cleanly (the lib.rs preamble change adds no unresolved-link warnings).
- [x] Full-mag download at `--mag-limit 14` completed successfully on a non-proxied connection (initial in-session attempt was a proxy-side drop, not a flathub or script issue).
- [x] `mkdocs build --strict` succeeds; new `catalog.md` renders, prev/next nav (installation → catalog → quickstart) is correct, and the relative link from `installation.md` resolves cleanly.

## Notes

- flathub is not on PyPI; the docs page covers the GitHub install (`pip install "flathub @ git+..."` or clone + local install).
- flathub's current client still calls `numpy.DataSource`, which NumPy 2.0 removed. The script shims that symbol back at import time so flathub itself doesn't need a patch.
- The new `download_gaia_flatiron.py` imports `load_hipparcos`, `merge_catalogs`, and the writers from `download_gaia_catalog.py` rather than duplicating them, so the bright-star merge logic stays in one place.

Closes #30.