### PR TITLE
Simplify and optimize solver core + Python bindings

### DIFF
--- a/python/src/camera_model.rs
+++ b/python/src/camera_model.rs
@@ -180,17 +180,14 @@ impl PyCameraModel {
     }
 
     fn __reduce__(slf: &Bound<'_, Self>) -> PyResult<(Py<PyAny>, (Vec<u8>,))> {
-        let inner = &slf.borrow().inner;
-        let bytes = postcard::to_allocvec(inner)
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        let bytes = crate::helpers::to_postcard_bytes(&slf.borrow().inner)?;
         let from_bytes = slf.get_type().getattr("_from_pickle_bytes")?;
         Ok((from_bytes.unbind(), (bytes,)))
     }
 
     #[staticmethod]
     fn _from_pickle_bytes(data: &[u8]) -> PyResult<Self> {
-        let inner: CameraModel = postcard::from_bytes::<CameraModel>(data)
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        let inner = crate::helpers::from_postcard_bytes::<CameraModel>(data)?;
         Ok(Self { inner })
     }
 

--- a/python/src/centroid.rs
+++ b/python/src/centroid.rs
@@ -1,6 +1,5 @@
 use numpy::ndarray;
 use numpy::PyArray2;
-use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 
 use crate::distortion::extract_distortion;
@@ -142,17 +141,14 @@ impl PyCentroid {
     }
 
     fn __reduce__(slf: &Bound<'_, Self>) -> PyResult<(Py<PyAny>, (Vec<u8>,))> {
-        let inner = &slf.borrow().inner;
-        let bytes = postcard::to_allocvec(inner)
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        let bytes = crate::helpers::to_postcard_bytes(&slf.borrow().inner)?;
         let from_bytes = slf.get_type().getattr("_from_pickle_bytes")?;
         Ok((from_bytes.unbind(), (bytes,)))
     }
 
     #[staticmethod]
     fn _from_pickle_bytes(data: &[u8]) -> PyResult<Self> {
-        let inner = postcard::from_bytes::<tetra3::Centroid>(data)
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        let inner = crate::helpers::from_postcard_bytes::<tetra3::Centroid>(data)?;
         Ok(Self { inner })
     }
 

--- a/python/src/distortion.rs
+++ b/python/src/distortion.rs
@@ -1,8 +1,7 @@
 use numpy::PyArray1;
-use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 
-use tetra3::distortion::polynomial::num_coeffs as poly_num_coeffs;
+use tetra3::num_coeffs as poly_num_coeffs;
 use tetra3::distortion::{Distortion, PolynomialDistortion, RadialDistortion};
 
 /// Helper: extract a Distortion enum from a Python RadialDistortion or PolynomialDistortion.
@@ -108,17 +107,14 @@ impl PyRadialDistortion {
     }
 
     fn __reduce__(slf: &Bound<'_, Self>) -> PyResult<(Py<PyAny>, (Vec<u8>,))> {
-        let inner = &slf.borrow().inner;
-        let bytes = postcard::to_allocvec(inner)
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        let bytes = crate::helpers::to_postcard_bytes(&slf.borrow().inner)?;
         let from_bytes = slf.get_type().getattr("_from_pickle_bytes")?;
         Ok((from_bytes.unbind(), (bytes,)))
     }
 
     #[staticmethod]
     fn _from_pickle_bytes(data: &[u8]) -> PyResult<Self> {
-        let inner = postcard::from_bytes::<RadialDistortion>(data)
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        let inner = crate::helpers::from_postcard_bytes::<RadialDistortion>(data)?;
         Ok(Self { inner })
     }
 
@@ -255,17 +251,14 @@ impl PyPolynomialDistortion {
     }
 
     fn __reduce__(slf: &Bound<'_, Self>) -> PyResult<(Py<PyAny>, (Vec<u8>,))> {
-        let inner = &slf.borrow().inner;
-        let bytes = postcard::to_allocvec(inner)
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        let bytes = crate::helpers::to_postcard_bytes(&slf.borrow().inner)?;
         let from_bytes = slf.get_type().getattr("_from_pickle_bytes")?;
         Ok((from_bytes.unbind(), (bytes,)))
     }
 
     #[staticmethod]
     fn _from_pickle_bytes(data: &[u8]) -> PyResult<Self> {
-        let inner = postcard::from_bytes::<PolynomialDistortion>(data)
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        let inner = crate::helpers::from_postcard_bytes::<PolynomialDistortion>(data)?;
         Ok(Self { inner })
     }
 

--- a/python/src/helpers.rs
+++ b/python/src/helpers.rs
@@ -1,5 +1,8 @@
 use numpy::PyReadonlyArray2;
+use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 
 use tetra3::solver::SolveResult;
 use tetra3::Centroid;
@@ -54,7 +57,9 @@ pub(crate) fn parse_solve_results_and_centroids(
 }
 
 /// Parse a single set of centroids from Python (list of Centroid or Nx2/Nx3 array).
-fn parse_centroids_single(centroids: &Bound<'_, pyo3::PyAny>) -> PyResult<Vec<Centroid>> {
+pub(crate) fn parse_centroids_single(
+    centroids: &Bound<'_, pyo3::PyAny>,
+) -> PyResult<Vec<Centroid>> {
     if let Ok(list) = centroids.cast::<pyo3::types::PyList>() {
         list.iter()
             .map(|item| {
@@ -86,5 +91,73 @@ fn parse_centroids_single(centroids: &Bound<'_, pyo3::PyAny>) -> PyResult<Vec<Ce
         Err(pyo3::exceptions::PyTypeError::new_err(
             "centroids must be a list of Centroid objects or an Nx2/Nx3 numpy array",
         ))
+    }
+}
+
+/// Serialize a value with postcard, mapping any error to a Python `RuntimeError`.
+///
+/// Shared by the pickle (`__reduce__`) implementations so the postcard call and
+/// its error conversion are written once rather than per type.
+pub(crate) fn to_postcard_bytes<T: Serialize>(value: &T) -> PyResult<Vec<u8>> {
+    postcard::to_allocvec(value).map_err(|e| PyRuntimeError::new_err(e.to_string()))
+}
+
+/// Deserialize a value from postcard bytes, mapping any error to a Python
+/// `RuntimeError`. Counterpart to [`to_postcard_bytes`].
+pub(crate) fn from_postcard_bytes<T: DeserializeOwned>(data: &[u8]) -> PyResult<T> {
+    postcard::from_bytes::<T>(data).map_err(|e| PyRuntimeError::new_err(e.to_string()))
+}
+
+/// Resolve image dimensions from either `image_shape=(height, width)` (numpy
+/// convention) or separate `image_width`/`image_height`. Exactly one form must
+/// be supplied. Returns `(width, height)`.
+pub(crate) fn resolve_image_dims(
+    image_shape: Option<(u32, u32)>,
+    image_width: Option<u32>,
+    image_height: Option<u32>,
+) -> PyResult<(u32, u32)> {
+    match (image_shape, image_width, image_height) {
+        (Some((h, w)), None, None) => Ok((w, h)),
+        (None, Some(w), Some(h)) => Ok((w, h)),
+        (Some(_), Some(_), _) | (Some(_), _, Some(_)) => Err(
+            pyo3::exceptions::PyValueError::new_err(
+                "Specify either image_shape or image_width/image_height, not both",
+            ),
+        ),
+        _ => Err(pyo3::exceptions::PyValueError::new_err(
+            "Must specify image dimensions via image_shape=(height, width) or image_width + image_height",
+        )),
+    }
+}
+
+/// Resolve an angle given as **exactly one** of a `*_deg` or `*_rad` option,
+/// returning radians (f32). The error messages are passed in so each caller
+/// keeps its own exact wording.
+pub(crate) fn exactly_one_angle_rad(
+    deg: Option<f64>,
+    rad: Option<f64>,
+    both_msg: &str,
+    neither_msg: &str,
+) -> PyResult<f32> {
+    match (deg, rad) {
+        (Some(d), None) => Ok((d as f32).to_radians()),
+        (None, Some(r)) => Ok(r as f32),
+        (Some(_), Some(_)) => Err(pyo3::exceptions::PyValueError::new_err(both_msg.to_string())),
+        (None, None) => Err(pyo3::exceptions::PyValueError::new_err(neither_msg.to_string())),
+    }
+}
+
+/// Resolve an optional angle given as **at most one** of a `*_deg` or `*_rad`
+/// option, returning `Some(radians)` or `None` when neither is given.
+pub(crate) fn at_most_one_angle_rad(
+    deg: Option<f64>,
+    rad: Option<f64>,
+    both_msg: &str,
+) -> PyResult<Option<f32>> {
+    match (deg, rad) {
+        (Some(d), None) => Ok(Some((d as f32).to_radians())),
+        (None, Some(r)) => Ok(Some(r as f32)),
+        (Some(_), Some(_)) => Err(pyo3::exceptions::PyValueError::new_err(both_msg.to_string())),
+        (None, None) => Ok(None),
     }
 }

--- a/python/src/solve_result.rs
+++ b/python/src/solve_result.rs
@@ -1,6 +1,5 @@
 use numpy::ndarray;
 use numpy::{PyArray1, PyArray2, PyReadonlyArray1};
-use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use pyo3::types::PyAny;
 
@@ -275,17 +274,14 @@ impl PySolveResult {
     }
 
     fn __reduce__(slf: &Bound<'_, Self>) -> PyResult<(Py<PyAny>, (Vec<u8>,))> {
-        let inner = &slf.borrow().inner;
-        let bytes = postcard::to_allocvec(inner)
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        let bytes = crate::helpers::to_postcard_bytes(&slf.borrow().inner)?;
         let from_bytes = slf.get_type().getattr("_from_pickle_bytes")?;
         Ok((from_bytes.unbind(), (bytes,)))
     }
 
     #[staticmethod]
     fn _from_pickle_bytes(data: &[u8]) -> PyResult<Self> {
-        let result = postcard::from_bytes::<SolveResult>(data)
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        let result = crate::helpers::from_postcard_bytes::<SolveResult>(data)?;
         Ok(Self::from_result(result))
     }
 

--- a/python/src/solver_database.rs
+++ b/python/src/solver_database.rs
@@ -1,17 +1,18 @@
-use numpy::PyReadonlyArray2;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 
 use tetra3::camera_model::CameraModel;
-use tetra3::distortion::calibrate::{calibrate_camera, CalibrateConfig, DistortionModelType};
+use tetra3::{calibrate_camera, CalibrateConfig, DistortionModelType};
 use tetra3::solver::{GenerateDatabaseConfig, SolveConfig, SolveStatus, SolverDatabase};
 use tetra3::Centroid;
 
 use crate::calibrate::PyCalibrateResult;
 use crate::camera_model::PyCameraModel;
 use crate::catalog_star::PyCatalogStar;
-use crate::centroid::PyCentroid;
-use crate::helpers::parse_solve_results_and_centroids;
+use crate::helpers::{
+    at_most_one_angle_rad, exactly_one_angle_rad, parse_centroids_single,
+    parse_solve_results_and_centroids, resolve_image_dims,
+};
 use crate::solve_result::PySolveResult;
 
 /// A star pattern database for plate solving.
@@ -217,83 +218,25 @@ impl PySolverDatabase {
         strict_hint: bool,
     ) -> PyResult<Option<PySolveResult>> {
         // Resolve FOV estimate: exactly one of deg or rad must be provided
-        let fov_rad = match (fov_estimate_deg, fov_estimate_rad) {
-            (Some(deg), None) => (deg as f32).to_radians(),
-            (None, Some(rad)) => rad as f32,
-            (Some(_), Some(_)) => {
-                return Err(pyo3::exceptions::PyValueError::new_err(
-                    "Specify exactly one of fov_estimate_deg or fov_estimate_rad, not both",
-                ));
-            }
-            (None, None) => {
-                return Err(pyo3::exceptions::PyValueError::new_err(
-                    "Must specify either fov_estimate_deg or fov_estimate_rad",
-                ));
-            }
-        };
+        let fov_rad = exactly_one_angle_rad(
+            fov_estimate_deg,
+            fov_estimate_rad,
+            "Specify exactly one of fov_estimate_deg or fov_estimate_rad, not both",
+            "Must specify either fov_estimate_deg or fov_estimate_rad",
+        )?;
 
         // Resolve image dimensions: image_shape=(h, w) or image_width + image_height
-        let (img_width, img_height) = match (image_shape, image_width, image_height) {
-            (Some((h, w)), None, None) => (w, h),
-            (None, Some(w), Some(h)) => (w, h),
-            (Some(_), Some(_), _) | (Some(_), _, Some(_)) => {
-                return Err(pyo3::exceptions::PyValueError::new_err(
-                    "Specify either image_shape or image_width/image_height, not both",
-                ));
-            }
-            _ => {
-                return Err(pyo3::exceptions::PyValueError::new_err(
-                    "Must specify image dimensions via image_shape=(height, width) or image_width + image_height",
-                ));
-            }
-        };
+        let (img_width, img_height) = resolve_image_dims(image_shape, image_width, image_height)?;
 
-        // Accept either a list of Centroid objects or an Nx2/Nx3 numpy array
-        let centroid_vec: Vec<Centroid> = if let Ok(list) = centroids.cast::<pyo3::types::PyList>()
-        {
-            list.iter()
-                .map(|item| {
-                    let c: PyCentroid = item.extract()?;
-                    Ok(c.inner)
-                })
-                .collect::<PyResult<Vec<Centroid>>>()?
-        } else if let Ok(arr) = centroids.extract::<PyReadonlyArray2<f64>>() {
-            let a = arr.as_array();
-            let ncols = a.shape()[1];
-            if ncols < 2 {
-                return Err(pyo3::exceptions::PyValueError::new_err(
-                    "centroids array must have at least 2 columns (x, y)",
-                ));
-            }
-            (0..a.shape()[0])
-                .map(|i| Centroid {
-                    x: a[[i, 0]] as f32,
-                    y: a[[i, 1]] as f32,
-                    mass: if ncols >= 3 {
-                        Some(a[[i, 2]] as f32)
-                    } else {
-                        None
-                    },
-                    cov: None,
-                })
-                .collect()
-        } else {
-            return Err(pyo3::exceptions::PyTypeError::new_err(
-                "centroids must be a list of Centroid objects or an Nx2/Nx3 numpy array of float64",
-            ));
-        };
+        // Accept either a list of Centroid objects or an Nx2/Nx3 numpy array.
+        let centroid_vec: Vec<Centroid> = parse_centroids_single(centroids)?;
 
         // Resolve FOV max error: at most one of deg or rad
-        let fov_max_err = match (fov_max_error_deg, fov_max_error_rad) {
-            (Some(deg), None) => Some((deg as f32).to_radians()),
-            (None, Some(rad)) => Some(rad as f32),
-            (Some(_), Some(_)) => {
-                return Err(pyo3::exceptions::PyValueError::new_err(
-                    "Specify at most one of fov_max_error_deg or fov_max_error_rad, not both",
-                ));
-            }
-            (None, None) => None,
-        };
+        let fov_max_err = at_most_one_angle_rad(
+            fov_max_error_deg,
+            fov_max_error_rad,
+            "Specify at most one of fov_max_error_deg or fov_max_error_rad, not both",
+        )?;
 
         // Use provided camera model, or create a default pinhole model from FOV
         let cam = match camera_model {
@@ -302,16 +245,11 @@ impl PySolverDatabase {
         };
 
         // Resolve hint uncertainty: at most one of deg or rad.
-        let hint_uncertainty = match (hint_uncertainty_deg, hint_uncertainty_rad) {
-            (Some(deg), None) => Some((deg as f32).to_radians()),
-            (None, Some(rad)) => Some(rad as f32),
-            (Some(_), Some(_)) => {
-                return Err(pyo3::exceptions::PyValueError::new_err(
-                    "Specify at most one of hint_uncertainty_deg or hint_uncertainty_rad",
-                ));
-            }
-            (None, None) => None,
-        };
+        let hint_uncertainty = at_most_one_angle_rad(
+            hint_uncertainty_deg,
+            hint_uncertainty_rad,
+            "Specify at most one of hint_uncertainty_deg or hint_uncertainty_rad",
+        )?;
 
         // Build quaternion from the hint, accepting either a 4-element [w, x, y, z]
         // quaternion or a 3×3 rotation matrix.
@@ -550,20 +488,7 @@ impl PySolverDatabase {
         };
 
         // Resolve image dimensions: image_shape=(h, w) or image_width + image_height
-        let (img_width, img_height) = match (image_shape, image_width, image_height) {
-            (Some((h, w)), None, None) => (w, h),
-            (None, Some(w), Some(h)) => (w, h),
-            (Some(_), Some(_), _) | (Some(_), _, Some(_)) => {
-                return Err(pyo3::exceptions::PyValueError::new_err(
-                    "Specify either image_shape or image_width/image_height, not both",
-                ));
-            }
-            _ => {
-                return Err(pyo3::exceptions::PyValueError::new_err(
-                    "Must specify image dimensions via image_shape=(height, width) or image_width + image_height",
-                ));
-            }
-        };
+        let (img_width, img_height) = resolve_image_dims(image_shape, image_width, image_height)?;
 
         let (sr_vec, cent_vec) = parse_solve_results_and_centroids(solve_results, centroids)?;
 

--- a/src/catalogs/gaia.rs
+++ b/src/catalogs/gaia.rs
@@ -1,15 +1,11 @@
 use crate::error::{Error, Result};
 use std::path::Path;
 
-#[allow(dead_code)]
 pub struct GaiaStar {
     pub source_id: i64,
     pub ra_deg: f32,
     pub dec_deg: f32,
     pub phot_g_mean_mag: f32,
-    pub phot_bp_mean_mag: f32,
-    pub phot_rp_mean_mag: f32,
-    pub parallax: Option<f32>,
     pub pmra: Option<f32>,
     pub pmdec: Option<f32>,
 }
@@ -19,7 +15,6 @@ pub struct GaiaStar {
 /// Binary format spec:
 /// - Header: magic "GDR3" (4 bytes) + version (u32 LE, value 1) + num_stars (u64 LE)
 /// - Per star (36 bytes): source_id (i64 LE) + ra (f64 LE) + dec (f64 LE) + mag (f32 LE) + pmra (f32 LE) + pmdec (f32 LE)
-#[allow(dead_code)]
 pub fn load_gaia_binary<P: AsRef<Path>>(path: P) -> Result<Vec<GaiaStar>> {
     use std::io::Read;
 
@@ -66,9 +61,6 @@ pub fn load_gaia_binary<P: AsRef<Path>>(path: P) -> Result<Vec<GaiaStar>> {
             ra_deg: ra as f32,
             dec_deg: dec as f32,
             phot_g_mean_mag: mag,
-            phot_bp_mean_mag: 0.0,
-            phot_rp_mean_mag: 0.0,
-            parallax: None,
             pmra: Some(pmra),
             pmdec: Some(pmdec),
         });

--- a/src/centroid_extraction.rs
+++ b/src/centroid_extraction.rs
@@ -498,14 +498,22 @@ fn estimate_background(
         return (0.0, 0.0);
     }
 
-    values.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
     let n = values.len();
 
-    // Median as robust background level
-    let median = if n % 2 == 0 {
-        (values[n / 2 - 1] + values[n / 2]) / 2.0
-    } else {
-        values[n / 2]
+    // Median as robust background level. Only the median (an order statistic) is
+    // needed, so partition in O(n) via select_nth instead of a full O(n log n)
+    // sort. For even n the median averages the two central order statistics:
+    // values[n/2] (the selected element) and values[n/2 - 1] (the max of the
+    // lower partition that select_nth leaves to its left).
+    let cmp = |a: &f32, b: &f32| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal);
+    let median = {
+        let (lower, nth, _) = values.select_nth_unstable_by(n / 2, cmp);
+        if n % 2 == 0 {
+            let prev = lower.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+            (prev + *nth) / 2.0
+        } else {
+            *nth
+        }
     };
 
     // Estimate noise from pixels at or below the median (uncontaminated by stars).
@@ -587,6 +595,11 @@ fn compute_blob_centroids(
     let w = width as usize;
     let h = height as usize;
     let bg_level_f64 = bg_level as f64;
+
+    // Reused across blobs to avoid a fresh allocation per component (dense
+    // fields can have thousands). The closure is `FnMut`, so it may borrow and
+    // `clear()` this buffer each iteration.
+    let mut annulus_vals: Vec<f32> = Vec::new();
 
     components
         .iter()
@@ -674,7 +687,7 @@ fn compute_blob_centroids(
             let c0 = min_col.saturating_sub(ANNULUS_MARGIN);
             let c1 = (max_col + ANNULUS_MARGIN + 1).min(w);
 
-            let mut annulus_vals: Vec<f32> = Vec::new();
+            annulus_vals.clear();
             for r in r0..r1 {
                 let row_off = r * w;
                 for c in c0..c1 {
@@ -685,16 +698,21 @@ fn compute_blob_centroids(
                 }
             }
 
-            // Median of annulus (residual local background in bg-subtracted image)
+            // Median of annulus (residual local background in bg-subtracted image).
+            // select_nth partitions in O(n); for even length the lower central
+            // order statistic is the max of the partition left of the selected mid.
             let local_bg = if annulus_vals.is_empty() {
                 0.0_f64
             } else {
-                annulus_vals.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
-                let mid = annulus_vals.len() / 2;
-                if annulus_vals.len() % 2 == 0 {
-                    (annulus_vals[mid - 1] + annulus_vals[mid]) as f64 / 2.0
+                let m = annulus_vals.len();
+                let mid = m / 2;
+                let (lower, nth, _) =
+                    annulus_vals.select_nth_unstable_by(mid, |a, b| a.partial_cmp(b).unwrap());
+                if m % 2 == 0 {
+                    let prev = lower.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+                    (prev + *nth) as f64 / 2.0
                 } else {
-                    annulus_vals[mid] as f64
+                    *nth as f64
                 }
             };
 

--- a/src/distortion/calibrate.rs
+++ b/src/distortion/calibrate.rs
@@ -22,8 +22,9 @@ use crate::solver::wcs_refine;
 use crate::solver::{SolveResult, SolveStatus, SolverDatabase};
 
 use super::fit::{
-    build_id_lookup, compute_corrected_rmse, fit_polynomial_sigma_clip,
-    fit_radial_centered_sigma_clip, MatchedPoint,
+    build_id_lookup, compute_corrected_rmse, compute_corrected_rmse_centered,
+    fit_polynomial_sigma_clip, fit_radial_centered_sigma_clip, project_to_matched_point,
+    MatchedPoint,
 };
 use super::polynomial::{num_coeffs, PolynomialDistortion};
 use super::radial::RadialDistortion;
@@ -476,27 +477,15 @@ fn multi_image_calibrate(
 
             for &(cent_idx, cat_idx) in &ref_img.matches {
                 let sv = &database.star_vectors[cat_idx];
-                let icrs_v = numeris::Vector3::from_array([sv[0], sv[1], sv[2]]);
-                let cam_v = rot * icrs_v;
-
-                if cam_v[2] <= 0.0 {
-                    continue;
-                }
-
-                // Ideal position using global pixel scale (consistent across all images)
-                let x_ideal = parity_sign * (cam_v[0] as f64) / (cam_v[2] as f64) / global_pixel_scale;
-                let y_ideal = (cam_v[1] as f64) / (cam_v[2] as f64) / global_pixel_scale;
-
-                // Observed position: raw centroid (no undistortion applied)
+                // Observed position: raw centroid (no undistortion applied).
+                // Ideal position uses the global pixel scale (consistent across images).
                 let x_obs = cents[cent_idx].x as f64;
                 let y_obs = cents[cent_idx].y as f64;
-
-                all_points.push(MatchedPoint {
-                    x_obs,
-                    y_obs,
-                    x_ideal,
-                    y_ideal,
-                });
+                if let Some(mp) =
+                    project_to_matched_point(rot, sv, parity_sign, global_pixel_scale, x_obs, y_obs)
+                {
+                    all_points.push(mp);
+                }
             }
         }
 
@@ -566,23 +555,8 @@ fn multi_image_calibrate(
         let rmse_after = if fit_crpix == [0.0, 0.0] {
             compute_corrected_rmse(&all_points, &mask, &dist)
         } else {
-            // Centered radial: distort on (x_ideal - cx, y_ideal - cy)
-            // and shift result back. Use a local helper closure.
-            let mut sum_sq = 0.0_f64;
-            let mut nn = 0usize;
-            for (i, p) in all_points.iter().enumerate() {
-                if !mask[i] {
-                    continue;
-                }
-                let (dx, dy) = dist.distort(p.x_ideal - fit_crpix[0], p.y_ideal - fit_crpix[1]);
-                let pred_x = dx + fit_crpix[0];
-                let pred_y = dy + fit_crpix[1];
-                let rx = p.x_obs - pred_x;
-                let ry = p.y_obs - pred_y;
-                sum_sq += rx * rx + ry * ry;
-                nn += 1;
-            }
-            if nn == 0 { 0.0 } else { (sum_sq / nn as f64).sqrt() }
+            // Centered radial: distort on (x_ideal - cx, y_ideal - cy) and shift back.
+            compute_corrected_rmse_centered(&all_points, &mask, &dist, fit_crpix)
         };
         let rmse_before = compute_corrected_rmse(&all_points, &mask, &Distortion::None);
 

--- a/src/distortion/fit.rs
+++ b/src/distortion/fit.rs
@@ -70,10 +70,6 @@ pub struct DistortionFitResult {
     pub n_outliers: usize,
     /// Number of sigma-clip iterations performed.
     pub iterations: u32,
-    /// Per-match inlier mask (true = inlier, false = outlier).
-    /// Matches are ordered as they appear across all solve results
-    /// (solve_results\[0\] matches first, then \[1\], etc.).
-    pub inlier_mask: Vec<bool>,
 }
 
 // ── Data structures for internal use ────────────────────────────────────────
@@ -137,7 +133,6 @@ pub fn fit_radial_distortion(
             n_inliers: 0,
             n_outliers: 0,
             iterations: 0,
-            inlier_mask: Vec::new(),
         };
     }
 
@@ -175,7 +170,6 @@ pub fn fit_radial_distortion(
         n_inliers,
         n_outliers: n - n_inliers,
         iterations: fit.iterations,
-        inlier_mask: fit.mask,
     }
 }
 
@@ -270,11 +264,7 @@ pub(super) fn fit_radial_centered_sigma_clip(
         if inlier_resids.is_empty() {
             break;
         }
-        let median = percentile(&inlier_resids, 0.5);
-        let mut abs_devs: Vec<f64> = inlier_resids.iter().map(|&r| (r - median).abs()).collect();
-        abs_devs.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        let mad = percentile(&abs_devs, 0.5);
-        let sigma = mad * 1.4826;
+        let sigma = mad_sigma(&inlier_resids);
         if sigma < 1e-12 {
             break;
         }
@@ -468,7 +458,7 @@ fn centered_radial_residuals(
 /// Like [`compute_corrected_rmse`] but applies an optional crpix shift
 /// before the distortion model evaluates. Used for centered radial where
 /// the model is anchored at `(cx, cy)` rather than the geometric origin.
-fn compute_corrected_rmse_centered(
+pub(super) fn compute_corrected_rmse_centered(
     points: &[MatchedPoint],
     mask: &[bool],
     distortion: &Distortion,
@@ -563,6 +553,40 @@ pub(super) struct PolyFitResult {
     pub iterations: u32,
 }
 
+/// Per-point radial residual (in pixels) of the forward SIP polynomial model.
+///
+/// For each matched point: evaluate the forward polynomial at the normalized
+/// ideal coordinates `(u, v) = (x_ideal, y_ideal) / scale`, then return the
+/// Euclidean distance between the observed offset and the modeled offset.
+fn poly_point_residuals(
+    points: &[MatchedPoint],
+    pairs: &[(u32, u32)],
+    scale: f64,
+    a_coeffs: &[f64],
+    b_coeffs: &[f64],
+) -> Vec<f64> {
+    points
+        .iter()
+        .map(|p| {
+            let u = p.x_ideal / scale;
+            let v = p.y_ideal / scale;
+            let dx_model: f64 = pairs
+                .iter()
+                .enumerate()
+                .map(|(i, &(pp, qq))| a_coeffs[i] * u.powi(pp as i32) * v.powi(qq as i32))
+                .sum();
+            let dy_model: f64 = pairs
+                .iter()
+                .enumerate()
+                .map(|(i, &(pp, qq))| b_coeffs[i] * u.powi(pp as i32) * v.powi(qq as i32))
+                .sum();
+            let rx = p.x_obs - p.x_ideal - dx_model * scale;
+            let ry = p.y_obs - p.y_ideal - dy_model * scale;
+            (rx * rx + ry * ry).sqrt()
+        })
+        .collect()
+}
+
 /// Fit a polynomial distortion model with iterative sigma-clipping.
 ///
 /// This is the core fitting loop extracted for reuse by multi-image calibration.
@@ -596,26 +620,7 @@ pub(super) fn fit_polynomial_sigma_clip(
         iterations = iter + 1;
 
         // Compute residuals using current model
-        let residuals: Vec<f64> = points
-            .iter()
-            .map(|p| {
-                let u = p.x_ideal / scale;
-                let v = p.y_ideal / scale;
-                let dx_model: f64 = pairs
-                    .iter()
-                    .enumerate()
-                    .map(|(i, &(pp, qq))| a_coeffs[i] * u.powi(pp as i32) * v.powi(qq as i32))
-                    .sum();
-                let dy_model: f64 = pairs
-                    .iter()
-                    .enumerate()
-                    .map(|(i, &(pp, qq))| b_coeffs[i] * u.powi(pp as i32) * v.powi(qq as i32))
-                    .sum();
-                let rx = p.x_obs - p.x_ideal - dx_model * scale;
-                let ry = p.y_obs - p.y_ideal - dy_model * scale;
-                (rx * rx + ry * ry).sqrt()
-            })
-            .collect();
+        let residuals = poly_point_residuals(points, &pairs, scale, &a_coeffs, &b_coeffs);
 
         // MAD-based robust clipping
         let inlier_resids: Vec<f64> = residuals
@@ -629,11 +634,7 @@ pub(super) fn fit_polynomial_sigma_clip(
             break;
         }
 
-        let median = percentile(&inlier_resids, 0.5);
-        let mut abs_devs: Vec<f64> = inlier_resids.iter().map(|&r| (r - median).abs()).collect();
-        abs_devs.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        let mad = percentile(&abs_devs, 0.5);
-        let sigma = mad * 1.4826;
+        let sigma = mad_sigma(&inlier_resids);
 
         if sigma < 1e-12 {
             break;
@@ -663,26 +664,7 @@ pub(super) fn fit_polynomial_sigma_clip(
 
     // Stage 2: recover outliers below a threshold
     if let Some(threshold_px) = config.stage2_threshold_px {
-        let residuals: Vec<f64> = points
-            .iter()
-            .map(|p| {
-                let u = p.x_ideal / scale;
-                let v = p.y_ideal / scale;
-                let dx_model: f64 = pairs
-                    .iter()
-                    .enumerate()
-                    .map(|(i, &(pp, qq))| a_coeffs[i] * u.powi(pp as i32) * v.powi(qq as i32))
-                    .sum();
-                let dy_model: f64 = pairs
-                    .iter()
-                    .enumerate()
-                    .map(|(i, &(pp, qq))| b_coeffs[i] * u.powi(pp as i32) * v.powi(qq as i32))
-                    .sum();
-                let rx = p.x_obs - p.x_ideal - dx_model * scale;
-                let ry = p.y_obs - p.y_ideal - dy_model * scale;
-                (rx * rx + ry * ry).sqrt()
-            })
-            .collect();
+        let residuals = poly_point_residuals(points, &pairs, scale, &a_coeffs, &b_coeffs);
 
         let mask_s2: Vec<bool> = residuals.iter().map(|&r| r <= threshold_px).collect();
         let n_recovered = mask_s2
@@ -766,7 +748,6 @@ pub fn fit_polynomial_distortion(
             n_inliers: 0,
             n_outliers: 0,
             iterations: 0,
-            inlier_mask: Vec::new(),
         };
     }
 
@@ -789,7 +770,6 @@ pub fn fit_polynomial_distortion(
             n_inliers: n,
             n_outliers: 0,
             iterations: 0,
-            inlier_mask: vec![true; n],
         };
     }
 
@@ -819,7 +799,6 @@ pub fn fit_polynomial_distortion(
         n_inliers,
         n_outliers: n - n_inliers,
         iterations: fit.iterations,
-        inlier_mask: fit.mask,
     }
 }
 
@@ -882,30 +861,48 @@ fn gather_matched_points(
             };
 
             let sv = &database.star_vectors[star_idx];
-            let icrs_v = numeris::Vector3::from_array([sv[0], sv[1], sv[2]]);
-            let cam_v = rot * icrs_v;
-
-            if cam_v[2] <= 0.0 {
-                continue;
-            }
-
-            // Project to pixel coordinates
-            let x_ideal = parity_sign * (cam_v[0] as f64) / (cam_v[2] as f64) / (pixel_scale as f64);
-            let y_ideal = (cam_v[1] as f64) / (cam_v[2] as f64) / (pixel_scale as f64);
-
             let x_obs = cents[cent_idx].x as f64;
             let y_obs = cents[cent_idx].y as f64;
-
-            points.push(MatchedPoint {
-                x_obs,
-                y_obs,
-                x_ideal,
-                y_ideal,
-            });
+            if let Some(mp) =
+                project_to_matched_point(rot, sv, parity_sign, pixel_scale as f64, x_obs, y_obs)
+            {
+                points.push(mp);
+            }
         }
     }
 
     points
+}
+
+/// Project a catalog star (ICRS unit vector `sv`) through `rot` into ideal
+/// pinhole pixel coordinates and pair it with an observed centroid `(x_obs,
+/// y_obs)`.
+///
+/// Returns `None` when the star projects behind the camera (`cam_z ≤ 0`).
+/// `parity_sign` is `-1.0` when the image x-axis is flipped; `pixel_scale` is
+/// radians per pixel (`1/focal_length_px`). Shared by the single-image gather
+/// and the multi-image calibration Phase 2.
+pub(super) fn project_to_matched_point(
+    rot: Matrix3<f32>,
+    sv: &[f32; 3],
+    parity_sign: f64,
+    pixel_scale: f64,
+    x_obs: f64,
+    y_obs: f64,
+) -> Option<MatchedPoint> {
+    let icrs_v = numeris::Vector3::from_array([sv[0], sv[1], sv[2]]);
+    let cam_v = rot * icrs_v;
+    if cam_v[2] <= 0.0 {
+        return None;
+    }
+    let x_ideal = parity_sign * (cam_v[0] as f64) / (cam_v[2] as f64) / pixel_scale;
+    let y_ideal = (cam_v[1] as f64) / (cam_v[2] as f64) / pixel_scale;
+    Some(MatchedPoint {
+        x_obs,
+        y_obs,
+        x_ideal,
+        y_ideal,
+    })
 }
 
 /// Compute RMS pixel residual (uncorrected) across all points.
@@ -956,6 +953,17 @@ pub(super) fn percentile(sorted: &[f64], p: f64) -> f64 {
     values.sort_by(|a, b| a.partial_cmp(b).unwrap());
     let idx = (p * (values.len() - 1) as f64).round() as usize;
     values[idx.min(values.len() - 1)]
+}
+
+/// MAD-derived σ estimate (`1.4826 · MAD`) of a residual slice.
+///
+/// Uses the [`percentile`] helper (which sorts internally) for both the median
+/// and the median-absolute-deviation, matching the legacy fit convention.
+fn mad_sigma(inlier_resids: &[f64]) -> f64 {
+    let median = percentile(inlier_resids, 0.5);
+    let abs_devs: Vec<f64> = inlier_resids.iter().map(|&r| (r - median).abs()).collect();
+    let mad = percentile(&abs_devs, 0.5);
+    mad * 1.4826
 }
 
 /// Fit the forward polynomial (ideal → distorted) by least-squares.

--- a/src/distortion/mod.rs
+++ b/src/distortion/mod.rs
@@ -19,18 +19,18 @@
 //!
 //! 2. **Fitted** from one or more solve results — either through
 //!    [`calibrate_camera`] (which fits a SIP polynomial model and returns a
-//!    fully-populated [`CameraModel`]) or directly via
-//!    [`fit::fit_radial_distortion`] for the simpler `(k1, k2, k3)` model.
+//!    fully-populated [`CameraModel`]) or directly via the internal radial
+//!    fitter for the simpler `(k1, k2, k3)` model.
 //!    Both fitters use iterative robust sigma-clipping to reject
 //!    mismatched stars.
 
-pub mod calibrate;
-pub mod fit;
-pub mod polynomial;
-pub mod radial;
+pub(crate) mod calibrate;
+pub(crate) mod fit;
+pub(crate) mod polynomial;
+pub(crate) mod radial;
 
 pub use calibrate::{calibrate_camera, CalibrateConfig, CalibrateResult, DistortionModelType};
-pub use polynomial::PolynomialDistortion;
+pub use polynomial::{num_coeffs, PolynomialDistortion};
 pub use radial::RadialDistortion;
 
 /// Lens distortion model.

--- a/src/distortion/polynomial.rs
+++ b/src/distortion/polynomial.rs
@@ -52,7 +52,7 @@
 /// # References
 ///
 /// - Shupe et al. (2005). *ASP Conf. Ser.* 347: 491. (SIP convention.)
-/// - See the [module-level docs](self) for full citations.
+/// - See the [`distortion` module docs](crate::distortion) for full citations.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct PolynomialDistortion {
     /// Polynomial order (2..=6 typically).
@@ -217,6 +217,7 @@ pub fn num_coeffs(order: u32) -> usize {
 ///   sum=1: (1,0)=1, (0,1)=2
 ///   sum=2: (2,0)=3, (1,1)=4, (0,2)=5
 ///   sum=3: (3,0)=6, (2,1)=7, (1,2)=8, (0,3)=9
+#[cfg(test)]
 pub fn coeff_index(p: u32, q: u32) -> usize {
     let s = p + q;
     // Base offset: number of terms for sums 0..(s-1) = s*(s+1)/2

--- a/src/distortion/radial.rs
+++ b/src/distortion/radial.rs
@@ -45,7 +45,7 @@
 /// - Conrady, A. E. (1919). *MNRAS* 79: 384.
 /// - Brown, D. C. (1966). *Photogrammetric Engineering* 32: 444.
 /// - Zhang, Z. (2000). *IEEE TPAMI* 22(11): 1330.
-/// - See the [module-level docs](self) for full citations.
+/// - See the [`distortion` module docs](crate::distortion) for full citations.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct RadialDistortion {
     /// First radial coefficient (barrel < 0, pincushion > 0).
@@ -158,15 +158,6 @@ impl RadialDistortion {
             }
         }
         (x, y)
-    }
-
-    /// Returns `true` if all coefficients are zero (no distortion).
-    pub fn is_zero(&self) -> bool {
-        self.k1 == 0.0
-            && self.k2 == 0.0
-            && self.k3 == 0.0
-            && self.p1 == 0.0
-            && self.p2 == 0.0
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,8 +193,8 @@ pub use centroid_extraction::{
     CentroidExtractionResult,
 };
 pub use distortion::{
-    calibrate_camera, CalibrateConfig, CalibrateResult, Distortion, DistortionModelType,
-    PolynomialDistortion, RadialDistortion,
+    calibrate_camera, num_coeffs, CalibrateConfig, CalibrateResult, Distortion,
+    DistortionModelType, PolynomialDistortion, RadialDistortion,
 };
 pub use solver::{
     DatabaseProperties, GenerateDatabaseConfig, SolveConfig, SolveResult, SolveStatus,

--- a/src/solver/combinations.rs
+++ b/src/solver/combinations.rs
@@ -25,7 +25,7 @@ impl<const K: usize> BreadthFirstCombinations<K> {
     /// Create a new iterator yielding `K`-combinations from `items`.
     ///
     /// `items` should be sorted in priority order (e.g. brightest star indices first).
-    /// The iterator yields `Vec<usize>` of length `K`, each containing elements from `items`.
+    /// The iterator yields `[usize; K]`, each containing elements from `items`.
     pub fn new(items: &[usize]) -> Self {
         let n = items.len();
         let mut bfc = Self {
@@ -46,9 +46,9 @@ impl<const K: usize> BreadthFirstCombinations<K> {
 }
 
 impl<const K: usize> Iterator for BreadthFirstCombinations<K> {
-    type Item = Vec<usize>;
+    type Item = [usize; K];
 
-    fn next(&mut self) -> Option<Vec<usize>> {
+    fn next(&mut self) -> Option<[usize; K]> {
         let Reverse((_, combo)) = self.heap.pop()?;
 
         // Generate successors: for each position, try incrementing by 1.
@@ -75,7 +75,7 @@ impl<const K: usize> Iterator for BreadthFirstCombinations<K> {
         }
 
         // Map positional indices to actual items.
-        Some(combo.iter().map(|&i| self.items[i as usize]).collect())
+        Some(std::array::from_fn(|j| self.items[combo[j] as usize]))
     }
 }
 
@@ -87,17 +87,17 @@ mod tests {
     fn test_bfs_combinations_complete() {
         // All C(5,3) = 10 combinations should be yielded
         let items: Vec<usize> = vec![10, 20, 30, 40, 50];
-        let combos: Vec<Vec<usize>> = BreadthFirstCombinations::<3>::new(&items).collect();
+        let combos: Vec<[usize; 3]> = BreadthFirstCombinations::<3>::new(&items).collect();
         assert_eq!(combos.len(), 10);
         // First combo should be the 3 "brightest" (lowest index)
-        assert_eq!(combos[0], vec![10, 20, 30]);
+        assert_eq!(combos[0], [10, 20, 30]);
     }
 
     #[test]
     fn test_bfs_combinations_order() {
         // Combinations should come in order of increasing index sum
         let items: Vec<usize> = (0..6).collect();
-        let combos: Vec<Vec<usize>> = BreadthFirstCombinations::<4>::new(&items).collect();
+        let combos: Vec<[usize; 4]> = BreadthFirstCombinations::<4>::new(&items).collect();
         assert_eq!(combos.len(), 15); // C(6,4) = 15
 
         // Verify sum ordering
@@ -111,16 +111,16 @@ mod tests {
     fn test_bfs_combinations_early_stop() {
         // Should be able to take just a few without enumerating all
         let items: Vec<usize> = (0..50).collect();
-        let first_10: Vec<Vec<usize>> =
+        let first_10: Vec<[usize; 4]> =
             BreadthFirstCombinations::<4>::new(&items).take(10).collect();
         assert_eq!(first_10.len(), 10);
-        assert_eq!(first_10[0], vec![0, 1, 2, 3]);
+        assert_eq!(first_10[0], [0, 1, 2, 3]);
     }
 
     #[test]
     fn test_bfs_too_few_items() {
         let items: Vec<usize> = vec![1, 2];
-        let combos: Vec<Vec<usize>> = BreadthFirstCombinations::<4>::new(&items).collect();
+        let combos: Vec<[usize; 4]> = BreadthFirstCombinations::<4>::new(&items).collect();
         assert!(combos.is_empty());
     }
 }

--- a/src/solver/database.rs
+++ b/src/solver/database.rs
@@ -222,7 +222,11 @@ impl SolverDatabase {
                     star_vectors[star_ind][1],
                     star_vectors[star_ind][2],
                 ]);
-                let nearby = star_catalog.query_indices_from_uvec(dir, pattern_stars_separation);
+                let nearby = star_catalog.query_indices_from_uvec_cached(
+                    dir,
+                    pattern_stars_separation,
+                    &star_vectors,
+                );
                 let occupied = nearby.iter().any(|&idx| keep_for_patterns[idx]);
                 if !occupied {
                     keep_for_patterns[star_ind] = true;
@@ -246,7 +250,8 @@ impl SolverDatabase {
             for center in &lattice_points {
                 // Find pattern stars within this lattice field
                 let center_v = numeris::Vector3::from_array([center[0], center[1], center[2]]);
-                let field_stars_all = star_catalog.query_indices_from_uvec(center_v, fov_angle);
+                let field_stars_all =
+                    star_catalog.query_indices_from_uvec_cached(center_v, fov_angle, &star_vectors);
 
                 // Keep only pattern-eligible stars, in brightness order
                 let field_pattern_stars: Vec<usize> = field_stars_all

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -11,12 +11,12 @@
 //!
 //! Reference: cedar-solve / tetra3 by Gustav Pettersson (ESA) and Steven Rosenthal.
 
-pub mod combinations;
-pub mod database;
-pub mod pattern;
-pub mod solve;
-pub mod track;
-pub mod wcs_refine;
+pub(crate) mod combinations;
+pub(crate) mod database;
+pub(crate) mod pattern;
+pub(crate) mod solve;
+pub(crate) mod track;
+pub(crate) mod wcs_refine;
 
 use serde::{Deserialize, Serialize};
 
@@ -543,8 +543,7 @@ impl SolveResult {
             // True pinhole pixel scale (1/f) from the angular FOV.
             let q = self.qicrs2cam.as_ref()?;
             let fov = self.fov_rad? as f64;
-            let f = (self.image_width.max(1) as f64 / 2.0) / (fov / 2.0).tan();
-            let pixel_scale = 1.0 / f;
+            let pixel_scale = pixel_scale_from_fov(self.image_width, fov);
 
             let ps = if self.parity_flip { -1.0 } else { 1.0 };
             let xr = ps * x * pixel_scale;
@@ -608,8 +607,7 @@ impl SolveResult {
             // True pinhole pixel scale (1/f) from the angular FOV.
             let q = self.qicrs2cam.as_ref()?;
             let fov = self.fov_rad? as f64;
-            let f = (self.image_width.max(1) as f64 / 2.0) / (fov / 2.0).tan();
-            let pixel_scale = 1.0 / f;
+            let pixel_scale = pixel_scale_from_fov(self.image_width, fov);
 
             let ra = ra_deg.to_radians();
             let dec = dec_deg.to_radians();
@@ -637,4 +635,12 @@ impl SolveResult {
             Some((ux, uy))
         }
     }
+}
+
+/// Pinhole pixel scale (radians per pixel) from an angular FOV and image width.
+///
+/// `pixel_scale = 1 / f`, with `f = (image_width / 2) / tan(fov / 2)`.
+fn pixel_scale_from_fov(image_width: u32, fov_rad: f64) -> f64 {
+    let f = (image_width.max(1) as f64 / 2.0) / (fov_rad / 2.0).tan();
+    1.0 / f
 }

--- a/src/solver/pattern.rs
+++ b/src/solver/pattern.rs
@@ -125,39 +125,10 @@ pub fn insert_pattern(
 
 // ── Pattern centroid ordering ───────────────────────────────────────────────
 
-/// Sort a pattern's star indices by each star's Euclidean distance from the
-/// pattern centroid (average position). This produces a canonical ordering
-/// that is invariant to the input star order, allowing image patterns to
-/// be matched against catalog patterns.
-pub fn sort_pattern_by_centroid_distance(
-    pattern: &mut [usize; PATTERN_SIZE],
-    vectors: &[[f32; 3]],
-) {
-    // Compute centroid (average of the 4 vectors).
-    let mut cx = 0.0f32;
-    let mut cy = 0.0f32;
-    let mut cz = 0.0f32;
-    for &idx in pattern.iter() {
-        let v = &vectors[idx];
-        cx += v[0];
-        cy += v[1];
-        cz += v[2];
-    }
-    cx /= PATTERN_SIZE as f32;
-    cy /= PATTERN_SIZE as f32;
-    cz /= PATTERN_SIZE as f32;
-
-    // Sort by squared distance from centroid (ascending).
-    pattern.sort_by(|&a, &b| {
-        let va = &vectors[a];
-        let vb = &vectors[b];
-        let da = (va[0] - cx).powi(2) + (va[1] - cy).powi(2) + (va[2] - cz).powi(2);
-        let db = (vb[0] - cx).powi(2) + (vb[1] - cy).powi(2) + (vb[2] - cz).powi(2);
-        da.partial_cmp(&db).unwrap_or(std::cmp::Ordering::Equal)
-    });
-}
-
-/// Same as above but operates on [u32; 4] with a separate vector lookup.
+/// Sort a pattern's star indices (`[u32; 4]`) by each star's Euclidean distance
+/// from the pattern centroid (average position). This produces a canonical
+/// ordering that is invariant to the input star order, allowing image patterns
+/// to be matched against catalog patterns.
 pub fn sort_u32_pattern_by_centroid_distance(
     pattern: &mut [u32; PATTERN_SIZE],
     star_vectors: &[[f32; 3]],

--- a/src/solver/solve.rs
+++ b/src/solver/solve.rs
@@ -27,7 +27,7 @@ use super::wcs_refine;
 use super::{SolveConfig, SolveResult, SolveStatus, SolverDatabase};
 
 /// Speed of light in km/s.
-const C_KM_S: f64 = 299_792.458;
+pub(super) const C_KM_S: f64 = 299_792.458;
 
 /// Classical stellar aberration: true ICRS unit vector → apparent.
 ///
@@ -436,9 +436,14 @@ impl SolverDatabase {
                     // Find catalog stars within the diagonal FOV
                     let image_center_icrs =
                         rotation_matrix.transpose() * Vector3::from_array([0.0, 0.0, 1.0]);
-                    let nearby_inds = self
-                        .star_catalog
-                        .query_indices_from_uvec(image_center_icrs, fov_diagonal / 2.0);
+                    // Use the stored (un-aberrated) unit vectors as the query
+                    // cache: they are bit-identical to `Star::uvec()` and aligned
+                    // with the catalog, so the candidate set is unchanged.
+                    let nearby_inds = self.star_catalog.query_indices_from_uvec_cached(
+                        image_center_icrs,
+                        fov_diagonal / 2.0,
+                        &self.star_vectors,
+                    );
 
                     // Project catalog stars to camera frame
                     let mut nearby_cam_positions: Vec<(usize, f32, f32)> = Vec::new();
@@ -522,102 +527,123 @@ impl SolverDatabase {
                         continue;
                     }
 
-                    // Derive rotation, FOV, and parity from the refined WCS
-                    let (refined_rotation, refined_fov, _) =
-                        wcs_refine::wcs_to_rotation(
-                            &wcs_result.cd_matrix,
-                            wcs_result.crval_rad[0],
-                            wcs_result.crval_rad[1],
-                            config.image_width,
-                        );
-
-                    // Build matched catalog IDs, centroid indices, and angular residuals.
-                    // True pinhole pixel scale derived from the angular `refined_fov`.
-                    let ps = {
-                        let f = (config.image_width.max(1) as f32 / 2.0)
-                            / (refined_fov / 2.0).tan();
-                        1.0 / f
-                    };
-                    let mut matched_cat_ids: Vec<i64> =
-                        Vec::with_capacity(wcs_result.matches.len());
-                    let mut matched_cent_inds: Vec<usize> =
-                        Vec::with_capacity(wcs_result.matches.len());
-                    let mut angular_residuals: Vec<f32> =
-                        Vec::with_capacity(wcs_result.matches.len());
-                    for &(cent_local_idx, cat_star_idx) in &wcs_result.matches {
-                        matched_cat_ids.push(self.star_catalog_ids[cat_star_idx]);
-                        matched_cent_inds.push(sorted_indices[cent_local_idx]);
-                        // Compute angular residual using rotation matrix
-                        let (px, py) = centroids_px[cent_local_idx];
-                        let ix = px as f32 * ps;
-                        let iy = py as f32 * ps;
-                        let iz = 1.0f32;
-                        let norm = (ix * ix + iy * iy + iz * iz).sqrt();
-                        let img_v = refined_rotation.transpose()
-                            * Vector3::from_array([ix / norm, iy / norm, iz / norm]);
-                        let sv = &star_vectors[cat_star_idx];
-                        let cat_v = Vector3::from_array([sv[0], sv[1], sv[2]]);
-                        let cross = img_v.cross(&cat_v);
-                        let ang = cross.norm().atan2(img_v.dot(&cat_v));
-                        angular_residuals.push(ang);
-                    }
-                    angular_residuals
-                        .sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-                    let rmse = if angular_residuals.is_empty() {
-                        0.0
-                    } else {
-                        (angular_residuals.iter().map(|r| r * r).sum::<f32>()
-                            / angular_residuals.len() as f32)
-                            .sqrt()
-                    };
-                    let p90e = if angular_residuals.is_empty() {
-                        0.0
-                    } else {
-                        angular_residuals
-                            [(0.9 * (angular_residuals.len() - 1) as f32) as usize]
-                    };
-                    let max_err = angular_residuals.last().copied().unwrap_or(0.0);
-
-                    // Convert rotation to quaternion
-                    let quat = Quaternion::from_rotation_matrix(&refined_rotation);
-
-                    // Build result camera model with refined focal length, image
-                    // dimensions (always filled from config, even if the input
-                    // camera_model was a Default placeholder), and detected parity.
-                    let mut result_cam = config.camera_model.clone();
-                    let refined_f = (config.image_width as f64 / 2.0)
-                        / (refined_fov as f64 / 2.0).tan();
-                    result_cam.focal_length_px = refined_f;
-                    result_cam.image_width = config.image_width;
-                    result_cam.image_height = config.image_height;
-                    result_cam.parity_flip = parity_flip;
-
-                    return SolveResult {
-                        qicrs2cam: Some(quat),
-                        fov_rad: Some(refined_fov),
-                        num_matches: Some(wcs_result.matches.len() as u32),
-                        rmse_rad: Some(rmse),
-                        p90e_rad: Some(p90e),
-                        max_err_rad: Some(max_err),
-                        prob: Some(prob_mismatch * self.props.num_patterns as f64),
-                        solve_time_ms: elapsed_ms(t0),
-                        status: SolveStatus::MatchFound,
+                    return self.finalize_solve_result(
+                        &wcs_result,
+                        star_vectors,
+                        &sorted_indices,
+                        &centroids_px,
+                        config,
                         parity_flip,
-                        matched_catalog_ids: matched_cat_ids,
-                        matched_centroid_indices: matched_cent_inds,
-                        image_width: config.image_width,
-                        image_height: config.image_height,
-                        cd_matrix: Some(wcs_result.cd_matrix),
-                        crval_rad: Some(wcs_result.crval_rad),
-                        camera_model: Some(result_cam),
-                        theta_rad: Some(wcs_result.theta_rad),
-                    };
-
+                        prob_mismatch * self.props.num_patterns as f64,
+                        t0,
+                    );
                 }
             }
         }
 
         SolveResult::failure(status, elapsed_ms(t0))
+    }
+
+    /// Assemble a successful [`SolveResult`] from a completed WCS refinement.
+    ///
+    /// Shared by the lost-in-space (`solve_at_fov`) and tracking
+    /// (`solve_with_hint`) paths. `star_vectors` is the (possibly
+    /// aberration-corrected) catalog unit-vector slice; `prob` is the caller's
+    /// false-positive probability estimate. The match set, residual statistics,
+    /// quaternion, and camera model are derived from `wcs_result`.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn finalize_solve_result(
+        &self,
+        wcs_result: &wcs_refine::WcsRefineResult,
+        star_vectors: &[[f32; 3]],
+        sorted_indices: &[usize],
+        centroids_px: &[(f64, f64)],
+        config: &SolveConfig,
+        parity_flip: bool,
+        prob: f64,
+        t0: Instant,
+    ) -> SolveResult {
+        // Derive rotation, FOV, and parity from the refined WCS.
+        let (refined_rotation, refined_fov, _) = wcs_refine::wcs_to_rotation(
+            &wcs_result.cd_matrix,
+            wcs_result.crval_rad[0],
+            wcs_result.crval_rad[1],
+            config.image_width,
+        );
+
+        // Build matched catalog IDs, centroid indices, and angular residuals.
+        // True pinhole pixel scale derived from the angular `refined_fov`.
+        let ps = {
+            let f = (config.image_width.max(1) as f32 / 2.0) / (refined_fov / 2.0).tan();
+            1.0 / f
+        };
+        let mut matched_cat_ids: Vec<i64> = Vec::with_capacity(wcs_result.matches.len());
+        let mut matched_cent_inds: Vec<usize> = Vec::with_capacity(wcs_result.matches.len());
+        let mut angular_residuals: Vec<f32> = Vec::with_capacity(wcs_result.matches.len());
+        for &(cent_local_idx, cat_star_idx) in &wcs_result.matches {
+            matched_cat_ids.push(self.star_catalog_ids[cat_star_idx]);
+            matched_cent_inds.push(sorted_indices[cent_local_idx]);
+            // Compute angular residual using rotation matrix
+            let (px, py) = centroids_px[cent_local_idx];
+            let ix = px as f32 * ps;
+            let iy = py as f32 * ps;
+            let iz = 1.0f32;
+            let norm = (ix * ix + iy * iy + iz * iz).sqrt();
+            let img_v = refined_rotation.transpose()
+                * Vector3::from_array([ix / norm, iy / norm, iz / norm]);
+            let sv = &star_vectors[cat_star_idx];
+            let cat_v = Vector3::from_array([sv[0], sv[1], sv[2]]);
+            let cross = img_v.cross(&cat_v);
+            let ang = cross.norm().atan2(img_v.dot(&cat_v));
+            angular_residuals.push(ang);
+        }
+        angular_residuals.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let rmse = if angular_residuals.is_empty() {
+            0.0
+        } else {
+            (angular_residuals.iter().map(|r| r * r).sum::<f32>() / angular_residuals.len() as f32)
+                .sqrt()
+        };
+        let p90e = if angular_residuals.is_empty() {
+            0.0
+        } else {
+            angular_residuals[(0.9 * (angular_residuals.len() - 1) as f32) as usize]
+        };
+        let max_err = angular_residuals.last().copied().unwrap_or(0.0);
+
+        // Convert rotation to quaternion
+        let quat = Quaternion::from_rotation_matrix(&refined_rotation);
+
+        // Build result camera model with refined focal length, image dimensions
+        // (always filled from config, even if the input camera_model was a
+        // Default placeholder), and detected parity.
+        let mut result_cam = config.camera_model.clone();
+        let refined_f = (config.image_width as f64 / 2.0) / (refined_fov as f64 / 2.0).tan();
+        result_cam.focal_length_px = refined_f;
+        result_cam.image_width = config.image_width;
+        result_cam.image_height = config.image_height;
+        result_cam.parity_flip = parity_flip;
+
+        SolveResult {
+            qicrs2cam: Some(quat),
+            fov_rad: Some(refined_fov),
+            num_matches: Some(wcs_result.matches.len() as u32),
+            rmse_rad: Some(rmse),
+            p90e_rad: Some(p90e),
+            max_err_rad: Some(max_err),
+            prob: Some(prob),
+            solve_time_ms: elapsed_ms(t0),
+            status: SolveStatus::MatchFound,
+            parity_flip,
+            matched_catalog_ids: matched_cat_ids,
+            matched_centroid_indices: matched_cent_inds,
+            image_width: config.image_width,
+            image_height: config.image_height,
+            cd_matrix: Some(wcs_result.cd_matrix),
+            crval_rad: Some(wcs_result.crval_rad),
+            camera_model: Some(result_cam),
+            theta_rad: Some(wcs_result.theta_rad),
+        }
     }
 }
 
@@ -651,7 +677,7 @@ fn build_fov_sweep(fov_estimate: f32, fov_max_error: Option<f32>, match_radius: 
     values
 }
 
-fn elapsed_ms(t0: Instant) -> f32 {
+pub(super) fn elapsed_ms(t0: Instant) -> f32 {
     t0.elapsed().as_secs_f32() * 1000.0
 }
 

--- a/src/solver/track.rs
+++ b/src/solver/track.rs
@@ -22,12 +22,9 @@ use tracing::debug;
 
 use crate::{Centroid, Quaternion};
 
-use super::solve::{aberration_correct, binomial_cdf, find_centroid_matches};
+use super::solve::{aberration_correct, binomial_cdf, elapsed_ms, find_centroid_matches, C_KM_S};
 use super::wcs_refine;
 use super::{SolveConfig, SolveResult, SolveStatus, SolverDatabase};
-
-/// Speed of light in km/s (duplicate of solve.rs C_KM_S; kept private here).
-const C_KM_S: f64 = 299_792.458;
 
 /// Minimum unique correspondences required to attempt the SVD step.
 const MIN_HINT_MATCHES: usize = 3;
@@ -83,9 +80,11 @@ impl SolverDatabase {
         let fov_diagonal = fov_rad * 1.42;
         let cone_radius =
             fov_diagonal / 2.0 + config.hint_uncertainty_rad + 2.0 * pixel_scale;
-        let nearby_inds = self
-            .star_catalog
-            .query_indices_from_uvec(boresight_icrs, cone_radius);
+        let nearby_inds = self.star_catalog.query_indices_from_uvec_cached(
+            boresight_icrs,
+            cone_radius,
+            &self.star_vectors,
+        );
 
         debug!(
             "Tracking: hint cone {:.3}° → {} catalog stars",
@@ -194,9 +193,11 @@ impl SolverDatabase {
         let image_center_icrs = rotation_matrix
             .transpose()
             * Vector3::from_array([0.0, 0.0, 1.0]);
-        let verify_inds = self
-            .star_catalog
-            .query_indices_from_uvec(image_center_icrs, fov_diagonal / 2.0);
+        let verify_inds = self.star_catalog.query_indices_from_uvec_cached(
+            image_center_icrs,
+            fov_diagonal / 2.0,
+            &self.star_vectors,
+        );
 
         let mut verify_positions: Vec<(usize, f32, f32)> = Vec::new();
         for &cat_idx in &verify_inds {
@@ -273,80 +274,16 @@ impl SolverDatabase {
             return SolveResult::failure(SolveStatus::NoMatch, elapsed_ms(t0));
         }
 
-        let (refined_rotation, refined_fov, _) = wcs_refine::wcs_to_rotation(
-            &wcs_result.cd_matrix,
-            wcs_result.crval_rad[0],
-            wcs_result.crval_rad[1],
-            config.image_width,
-        );
-
-        // ── Build matched IDs / residuals ──
-        // True pinhole pixel scale derived from the angular `refined_fov`.
-        let ps = {
-            let f = (config.image_width.max(1) as f32 / 2.0) / (refined_fov / 2.0).tan();
-            1.0 / f
-        };
-        let mut matched_cat_ids: Vec<i64> = Vec::with_capacity(wcs_result.matches.len());
-        let mut matched_cent_inds: Vec<usize> = Vec::with_capacity(wcs_result.matches.len());
-        let mut angular_residuals: Vec<f32> = Vec::with_capacity(wcs_result.matches.len());
-        for &(cent_local_idx, cat_star_idx) in &wcs_result.matches {
-            matched_cat_ids.push(self.star_catalog_ids[cat_star_idx]);
-            matched_cent_inds.push(sorted_indices[cent_local_idx]);
-            let (px, py) = centroids_px[cent_local_idx];
-            let ix = px as f32 * ps;
-            let iy = py as f32 * ps;
-            let iz = 1.0f32;
-            let norm = (ix * ix + iy * iy + iz * iz).sqrt();
-            let img_v = refined_rotation
-                .transpose()
-                * Vector3::from_array([ix / norm, iy / norm, iz / norm]);
-            let sv = &self.star_vectors[cat_star_idx];
-            let cat_v = Vector3::from_array([sv[0], sv[1], sv[2]]);
-            let cross = img_v.cross(&cat_v);
-            let ang = cross.norm().atan2(img_v.dot(&cat_v));
-            angular_residuals.push(ang);
-        }
-        angular_residuals.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-        let rmse = if angular_residuals.is_empty() {
-            0.0
-        } else {
-            (angular_residuals.iter().map(|r| r * r).sum::<f32>() / angular_residuals.len() as f32)
-                .sqrt()
-        };
-        let p90e = if angular_residuals.is_empty() {
-            0.0
-        } else {
-            angular_residuals[(0.9 * (angular_residuals.len() - 1) as f32) as usize]
-        };
-        let max_err = angular_residuals.last().copied().unwrap_or(0.0);
-
-        let quat = Quaternion::from_rotation_matrix(&refined_rotation);
-
-        let mut result_cam = config.camera_model.clone();
-        let refined_f = (config.image_width as f64 / 2.0) / (refined_fov as f64 / 2.0).tan();
-        result_cam.focal_length_px = refined_f;
-        result_cam.parity_flip = parity_flip;
-
-        SolveResult {
-            qicrs2cam: Some(quat),
-            fov_rad: Some(refined_fov),
-            num_matches: Some(wcs_result.matches.len() as u32),
-            rmse_rad: Some(rmse),
-            p90e_rad: Some(p90e),
-            max_err_rad: Some(max_err),
-            prob: Some(prob_mismatch),
-            solve_time_ms: elapsed_ms(t0),
-            status: SolveStatus::MatchFound,
+        self.finalize_solve_result(
+            &wcs_result,
+            &self.star_vectors,
+            &sorted_indices,
+            &centroids_px,
+            config,
             parity_flip,
-            matched_catalog_ids: matched_cat_ids,
-            matched_centroid_indices: matched_cent_inds,
-            image_width: config.image_width,
-            image_height: config.image_height,
-            cd_matrix: Some(wcs_result.cd_matrix),
-            crval_rad: Some(wcs_result.crval_rad),
-            camera_model: Some(result_cam),
-            theta_rad: Some(wcs_result.theta_rad),
-        }
+            prob_mismatch,
+            t0,
+        )
     }
 }
 
@@ -399,8 +336,4 @@ fn wahba_svd_dynamic(
     let r = r64.cast::<f32>();
     let det_ok = r.det() > 0.0;
     (r, det_ok)
-}
-
-fn elapsed_ms(t0: Instant) -> f32 {
-    t0.elapsed().as_secs_f32() * 1000.0
 }

--- a/src/solver/wcs_refine.rs
+++ b/src/solver/wcs_refine.rs
@@ -115,6 +115,7 @@ pub fn cd_from_theta(theta: f64, pixel_scale: f64, parity_flip: bool) -> [[f64; 
 /// Decompose a CD matrix into rotation angle, pixel scale (x and y), and parity.
 ///
 /// Returns `(theta_rad, scale_x, scale_y, parity_flip)`.
+#[cfg(test)]
 pub fn decompose_cd(cd: &[[f64; 2]; 2]) -> (f64, f64, f64, bool) {
     let det = cd[0][0] * cd[1][1] - cd[0][1] * cd[1][0];
     let parity_flip = det < 0.0;
@@ -256,6 +257,43 @@ fn predict_tanplane(px: f64, py: f64, cos_t: f64, sin_t: f64, ps: f64) -> (f64, 
     (xi, eta)
 }
 
+/// Decode a catalog star's ICRS unit vector into `(ra, dec)` in radians.
+#[inline]
+fn sv_to_radec(sv: &[f32; 3]) -> (f64, f64) {
+    let ra = (sv[1] as f64).atan2(sv[0] as f64);
+    let dec = (sv[2] as f64).asin();
+    (ra, dec)
+}
+
+/// Accumulate one matched star's contribution to the 3-parameter
+/// `[δθ, dξ₀, dη₀]` normal equations `AᵀA x = Aᵀb`.
+///
+/// Jacobian rows are `ξ: [∂ξ/∂θ, 1, 0]` and `η: [∂η/∂θ, 0, 1]`, with
+/// `∂ξ/∂θ = ps·(-sinθ·px − cosθ·py)` and `∂η/∂θ = ps·(cosθ·px − sinθ·py)`.
+#[inline]
+fn accumulate_normal_equations(
+    ata: &mut [[f64; 3]; 3],
+    atb: &mut [f64; 3],
+    px: f64,
+    py: f64,
+    cos_t: f64,
+    sin_t: f64,
+    ps: f64,
+    r_xi: f64,
+    r_eta: f64,
+) {
+    let j_xi_theta = ps * (-sin_t * px - cos_t * py);
+    let j_eta_theta = ps * (cos_t * px - sin_t * py);
+    let jxi = [j_xi_theta, 1.0, 0.0];
+    let jeta = [j_eta_theta, 0.0, 1.0];
+    for i in 0..3 {
+        for j in 0..3 {
+            ata[i][j] += jxi[i] * jxi[j] + jeta[i] * jeta[j];
+        }
+        atb[i] += jxi[i] * r_xi + jeta[i] * r_eta;
+    }
+}
+
 /// Predict pixel coords from tangent-plane coords (inverse of predict_tanplane).
 ///
 /// `px = (1/ps)·(cos θ · ξ + sin θ · η)`
@@ -282,13 +320,27 @@ pub struct WcsRefineResult {
     pub matches: Vec<(usize, usize)>,
     /// RMSE of angular residuals in radians.
     pub rmse_rad: f64,
-    /// 90th-percentile angular residual in radians.
-    pub p90e_rad: f64,
-    /// Maximum angular residual in radians.
-    pub max_err_rad: f64,
 }
 
 // ── Main refinement entry point ─────────────────────────────────────────────
+
+/// MAD → σ scale factor for a Gaussian distribution.
+const MAD_SCALE: f64 = 1.4826;
+
+/// Robust statistics of a residual list: the median residual and the
+/// MAD-derived standard-deviation estimate (`MAD_SCALE · MAD`).
+///
+/// Both the median and the median-absolute-deviation use the simple midpoint of
+/// the sorted values (`v[len / 2]`) — the refinement's existing convention.
+fn residual_median_sigma(residuals: &[(usize, f64)]) -> (f64, f64) {
+    let mut res_vals: Vec<f64> = residuals.iter().map(|&(_, r)| r).collect();
+    res_vals.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let median = res_vals[res_vals.len() / 2];
+    let mut abs_devs: Vec<f64> = res_vals.iter().map(|r| (r - median).abs()).collect();
+    abs_devs.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let mad = abs_devs[abs_devs.len() / 2];
+    (median, MAD_SCALE * mad)
+}
 
 /// Constrained iterative WCS TAN-projection refinement.
 ///
@@ -329,7 +381,6 @@ pub fn wcs_refine(
     max_iterations: u32,
 ) -> WcsRefineResult {
     // ── Constants ────────────────────────────────────────────────────────
-    const MAD_SCALE: f64 = 1.4826; // MAD → σ for Gaussian
     const CLIP_NSIGMA: f64 = 3.0;
     const CONVERGENCE_RAD: f64 = 1e-12; // tangent-plane offset convergence
 
@@ -396,8 +447,7 @@ pub fn wcs_refine(
 
             for &(cent_idx, cat_idx) in &current_matches {
                 let sv = &star_vectors[cat_idx];
-                let star_ra = (sv[1] as f64).atan2(sv[0] as f64);
-                let star_dec = (sv[2] as f64).asin();
+                let (star_ra, star_dec) = sv_to_radec(sv);
 
                 let Some((xi_cat, eta_cat)) = tan_project(star_ra, star_dec, crval_ra, crval_dec) else {
                     continue;
@@ -410,24 +460,9 @@ pub fn wcs_refine(
                 let r_xi = xi_cat - xi_pred;
                 let r_eta = eta_cat - eta_pred;
 
-                // Jacobian rows:
-                // ξ row: [∂ξ/∂θ, 1, 0] where ∂ξ/∂θ = ps·(-sin θ · px - cos θ · py)
-                // η row: [∂η/∂θ, 0, 1] where ∂η/∂θ = ps·(cos θ · px - sin θ · py)
-                let j_xi_theta = ps * (-sin_t * px - cos_t * py);
-                let j_eta_theta = ps * (cos_t * px - sin_t * py);
-
-                // ξ row: J = [j_xi_theta, 1, 0]
-                let jxi = [j_xi_theta, 1.0, 0.0];
-                // η row: J = [j_eta_theta, 0, 1]
-                let jeta = [j_eta_theta, 0.0, 1.0];
-
-                // Accumulate AᵀA and Aᵀb
-                for i in 0..3 {
-                    for j in 0..3 {
-                        ata[i][j] += jxi[i] * jxi[j] + jeta[i] * jeta[j];
-                    }
-                    atb[i] += jxi[i] * r_xi + jeta[i] * r_eta;
-                }
+                accumulate_normal_equations(
+                    &mut ata, &mut atb, px, py, cos_t, sin_t, ps, r_xi, r_eta,
+                );
                 n_valid += 1;
             }
 
@@ -469,8 +504,7 @@ pub fn wcs_refine(
         let mut residuals: Vec<(usize, f64)> = Vec::with_capacity(current_matches.len());
         for (match_idx, &(cent_idx, cat_idx)) in current_matches.iter().enumerate() {
             let sv = &star_vectors[cat_idx];
-            let star_ra = (sv[1] as f64).atan2(sv[0] as f64);
-            let star_dec = (sv[2] as f64).asin();
+            let (star_ra, star_dec) = sv_to_radec(sv);
 
             if let Some((xi_cat, eta_cat)) = tan_project(star_ra, star_dec, crval_ra, crval_dec) {
                 let (px, py) = centroids_px[cent_idx];
@@ -482,17 +516,19 @@ pub fn wcs_refine(
             }
         }
 
+        // Robust residual statistics (median, MAD-derived σ), computed once per
+        // iteration and reused by both Phase C clipping and Phase D's adaptive
+        // match radius.
+        let mad_stats = if residuals.len() >= 6 {
+            Some(residual_median_sigma(&residuals))
+        } else {
+            None
+        };
+
         // ── Phase C: MAD-based outlier rejection ────────────────────────
         let mut n_rejected = 0usize;
 
-        if residuals.len() >= 6 {
-            let mut res_vals: Vec<f64> = residuals.iter().map(|&(_, r)| r).collect();
-            res_vals.sort_by(|a, b| a.partial_cmp(b).unwrap());
-            let median = res_vals[res_vals.len() / 2];
-            let mut abs_devs: Vec<f64> = res_vals.iter().map(|r| (r - median).abs()).collect();
-            abs_devs.sort_by(|a, b| a.partial_cmp(b).unwrap());
-            let mad = abs_devs[abs_devs.len() / 2];
-            let sigma_est = MAD_SCALE * mad;
+        if let Some((median, sigma_est)) = mad_stats {
             let clip_threshold = median + CLIP_NSIGMA * sigma_est;
 
             let old_len = current_matches.len();
@@ -527,17 +563,8 @@ pub fn wcs_refine(
             // Pixel radius for matching
             let radius_px = match_radius_rad as f64 / ps;
 
-            // Adaptive radius from MAD if available
-            let adaptive_radius_px = if residuals.len() >= 6 {
-                let mut res_vals: Vec<f64> = residuals.iter().map(|&(_, r)| r).collect();
-                res_vals.sort_by(|a, b| a.partial_cmp(b).unwrap());
-                let mad = {
-                    let median = res_vals[res_vals.len() / 2];
-                    let mut ad: Vec<f64> = res_vals.iter().map(|r| (r - median).abs()).collect();
-                    ad.sort_by(|a, b| a.partial_cmp(b).unwrap());
-                    ad[ad.len() / 2]
-                };
-                let sigma_est = MAD_SCALE * mad;
+            // Adaptive radius from the MAD σ computed above (reused, not recomputed).
+            let adaptive_radius_px = if let Some((_, sigma_est)) = mad_stats {
                 (5.0 * sigma_est / ps).max(2.5).min(radius_px)
             } else {
                 radius_px
@@ -564,8 +591,7 @@ pub fn wcs_refine(
             let mut predicted: Vec<(usize, f64, f64)> = Vec::new();
             for &cat_idx in &nearby_indices {
                 let sv = &star_vectors[cat_idx];
-                let sra = (sv[1] as f64).atan2(sv[0] as f64);
-                let sdec = (sv[2] as f64).asin();
+                let (sra, sdec) = sv_to_radec(sv);
                 if let Some((xi, eta)) = tan_project(sra, sdec, crval_ra, crval_dec) {
                     let (pred_x, pred_y) = predict_pixel(xi, eta, cos_t, sin_t, inv_ps);
                     predicted.push((cat_idx, pred_x, pred_y));
@@ -618,8 +644,7 @@ pub fn wcs_refine(
         let mut residuals: Vec<(usize, f64)> = Vec::new();
         for (match_idx, &(cent_idx, cat_idx)) in current_matches.iter().enumerate() {
             let sv = &star_vectors[cat_idx];
-            let sra = (sv[1] as f64).atan2(sv[0] as f64);
-            let sdec = (sv[2] as f64).asin();
+            let (sra, sdec) = sv_to_radec(sv);
             if let Some((xi_cat, eta_cat)) = tan_project(sra, sdec, crval_ra, crval_dec) {
                 let (px, py) = centroids_px[cent_idx];
                 let (xi_pred, eta_pred) = predict_tanplane(px, py, cos_t, sin_t, ps);
@@ -633,13 +658,7 @@ pub fn wcs_refine(
             break;
         }
 
-        let mut res_vals: Vec<f64> = residuals.iter().map(|&(_, r)| r).collect();
-        res_vals.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        let median = res_vals[res_vals.len() / 2];
-        let mut abs_devs: Vec<f64> = res_vals.iter().map(|r| (r - median).abs()).collect();
-        abs_devs.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        let mad = abs_devs[abs_devs.len() / 2];
-        let sigma_est = MAD_SCALE * mad;
+        let (median, sigma_est) = residual_median_sigma(&residuals);
         let clip_threshold = median + CLIP_NSIGMA * sigma_est;
 
         let mut keep: Vec<(usize, usize)> = Vec::new();
@@ -671,25 +690,15 @@ pub fn wcs_refine(
             let mut atb = [0.0f64; 3];
             for &(cent_idx, cat_idx) in &current_matches {
                 let sv = &star_vectors[cat_idx];
-                let sra = (sv[1] as f64).atan2(sv[0] as f64);
-                let sdec = (sv[2] as f64).asin();
+                let (sra, sdec) = sv_to_radec(sv);
                 if let Some((xi_cat, eta_cat)) = tan_project(sra, sdec, crval_ra, crval_dec) {
                     let (px, py) = centroids_px[cent_idx];
                     let (xi_pred, eta_pred) = predict_tanplane(px, py, cos_t, sin_t, ps);
                     let r_xi = xi_cat - xi_pred;
                     let r_eta = eta_cat - eta_pred;
-
-                    let j_xi_theta = ps * (-sin_t * px - cos_t * py);
-                    let j_eta_theta = ps * (cos_t * px - sin_t * py);
-                    let jxi = [j_xi_theta, 1.0, 0.0];
-                    let jeta = [j_eta_theta, 0.0, 1.0];
-
-                    for i in 0..3 {
-                        for j in 0..3 {
-                            ata[i][j] += jxi[i] * jxi[j] + jeta[i] * jeta[j];
-                        }
-                        atb[i] += jxi[i] * r_xi + jeta[i] * r_eta;
-                    }
+                    accumulate_normal_equations(
+                        &mut ata, &mut atb, px, py, cos_t, sin_t, ps, r_xi, r_eta,
+                    );
                 }
             }
             if let Some(sol) = solve_3x3(&ata, &atb) {
@@ -708,8 +717,7 @@ pub fn wcs_refine(
     let mut final_residuals: Vec<f64> = Vec::with_capacity(current_matches.len());
     for &(cent_idx, cat_idx) in &current_matches {
         let sv = &star_vectors[cat_idx];
-        let sra = (sv[1] as f64).atan2(sv[0] as f64);
-        let sdec = (sv[2] as f64).asin();
+        let (sra, sdec) = sv_to_radec(sv);
         if let Some((xi_cat, eta_cat)) = tan_project(sra, sdec, crval_ra, crval_dec) {
             let (px, py) = centroids_px[cent_idx];
             let (xi_pred, eta_pred) = predict_tanplane(px, py, cos_t, sin_t, ps);
@@ -750,8 +758,6 @@ pub fn wcs_refine(
         theta_rad: theta,
         matches: current_matches,
         rmse_rad: rmse,
-        p90e_rad: p90e,
-        max_err_rad: max_err,
     }
 }
 

--- a/src/starcatalog.rs
+++ b/src/starcatalog.rs
@@ -112,8 +112,43 @@ impl StarCatalog {
     /// Query stars around a (possibly non-unit) direction vector.
     ///
     /// `dir` is normalized internally; `radius_rad` is clamped to `[0, π]`.
-    /// Returns indices into the internal star storage.
+    /// Returns indices into the internal star storage. Each candidate star's
+    /// unit vector is recomputed from its `(ra, dec)` via trigonometry; for hot
+    /// paths that already hold precomputed unit vectors, prefer
+    /// [`query_indices_from_uvec_cached`](Self::query_indices_from_uvec_cached).
     pub fn query_indices_from_uvec(&self, dir: Vector3<f32>, radius_rad: f32) -> Vec<usize> {
+        self.query_impl(dir, radius_rad, None)
+    }
+
+    /// Same as [`query_indices_from_uvec`](Self::query_indices_from_uvec) but
+    /// reads each candidate star's unit vector from `unit_vectors` instead of
+    /// recomputing it via `sin`/`cos`.
+    ///
+    /// `unit_vectors` MUST be index-aligned with [`stars`](Self::stars) (i.e.
+    /// `unit_vectors[i]` is the unit vector of `stars()[i]`). When that holds,
+    /// the result is identical to `query_indices_from_uvec`, just without the
+    /// per-star trigonometry — a meaningful saving when this is called once per
+    /// catalog star (database generation) or per solve candidate.
+    pub(crate) fn query_indices_from_uvec_cached(
+        &self,
+        dir: Vector3<f32>,
+        radius_rad: f32,
+        unit_vectors: &[[f32; 3]],
+    ) -> Vec<usize> {
+        debug_assert_eq!(
+            unit_vectors.len(),
+            self.stars.len(),
+            "unit_vectors cache must be index-aligned with stars"
+        );
+        self.query_impl(dir, radius_rad, Some(unit_vectors))
+    }
+
+    fn query_impl(
+        &self,
+        dir: Vector3<f32>,
+        radius_rad: f32,
+        cache: Option<&[[f32; 3]]>,
+    ) -> Vec<usize> {
         if self.is_empty() {
             return Vec::new();
         }
@@ -147,13 +182,13 @@ impl StarCatalog {
 
             if lon_max - lon_min >= TAU {
                 for lon_bin in 0..self.n_lon {
-                    self.collect_cell_matches(lat_bin, lon_bin, dir, cos_radius, &mut out);
+                    self.collect_cell_matches(lat_bin, lon_bin, dir, cos_radius, cache, &mut out);
                 }
                 continue;
             }
 
             self.for_each_wrapped_lon_bin(lon_min, lon_max, |lon_bin| {
-                self.collect_cell_matches(lat_bin, lon_bin, dir, cos_radius, &mut out);
+                self.collect_cell_matches(lat_bin, lon_bin, dir, cos_radius, cache, &mut out);
             });
         }
 
@@ -179,6 +214,7 @@ impl StarCatalog {
         lon_bin: u32,
         dir: Vector3<f32>,
         cos_radius: f32,
+        cache: Option<&[[f32; 3]]>,
         out: &mut Vec<usize>,
     ) {
         let cell = (lat_bin * self.n_lon + lon_bin) as usize;
@@ -187,8 +223,10 @@ impl StarCatalog {
 
         for flat_idx in start..end {
             let star_idx = self.star_indices[flat_idx] as usize;
-            let star = &self.stars[star_idx];
-            let star_dir = star.uvec();
+            let star_dir = match cache {
+                Some(vectors) => Vector3::from_array(vectors[star_idx]),
+                None => self.stars[star_idx].uvec(),
+            };
             if dir.dot(&star_dir) >= cos_radius {
                 out.push(star_idx);
             }


### PR DESCRIPTION
## Summary

Behavior-preserving simplification and optimization of the solver, distortion,
and Python-binding code. No public API changes (the `lib.rs` re-export facade is
unchanged); the one user-visible win is a **~2.5× speedup** on the TESS
solve+calibration path.

Tracked in #33 — this closes most of the checked items there.

## Commit 1 — Simplify and optimize solver core

**Dead code**
- Remove unused `RadialDistortion::is_zero`, three never-read `GaiaStar` fields,
  the dead `[usize;4]` `sort_pattern_by_centroid_distance` variant, and unread
  `WcsRefineResult{p90e_rad,max_err_rad}` / `DistortionFitResult.inlier_mask` fields.
- Gate test-only `coeff_index` / `decompose_cd` behind `#[cfg(test)]`.

**API surface**
- Make internal `solver/*` and `distortion/*` submodules `pub(crate)` (facade
  re-exports unchanged); re-export `num_coeffs` at the crate root.

**De-duplication**
- `SolverDatabase::finalize_solve_result` shared by `solve_at_fov` and
  `solve_with_hint`; hoist duplicated `C_KM_S` / `elapsed_ms`.
- `fit.rs`: `poly_point_residuals`, `mad_sigma`, reuse of
  `compute_corrected_rmse_centered`, and `project_to_matched_point` (shared with
  multi-image calibration).
- `wcs_refine`: `residual_median_sigma` (collapses 3 MAD blocks) + removal of the
  redundant per-iteration double-MAD; `sv_to_radec`, `accumulate_normal_equations`.
- `solver/mod.rs`: local `pixel_scale_from_fov` for the two pixel↔world fallbacks.

**Performance (correctness-neutral)**
- Cache star unit vectors in cone queries (`query_indices_from_uvec_cached`): DB
  generation, solve verification, and tracking pass the precomputed,
  index-aligned `SolverDatabase.star_vectors` instead of recomputing 4 trig ops
  per star per scan. **47.3s → 18.5s** on the TESS suite (stash-measured). Zero
  serialization change — existing databases load unchanged.
- `centroid_extraction`: `select_nth_unstable` for background/annulus medians;
  reuse one annulus buffer across blobs.
- `BreadthFirstCombinations` yields `[usize; K]` instead of a heap `Vec` per step.

## Commit 2 — Simplify Python bindings

- `to_postcard_bytes` / `from_postcard_bytes` helpers across all five
  `__reduce__` / `_from_pickle_bytes` sites.
- Reuse `parse_centroids_single` in `solve_from_centroids`.
- Extract `resolve_image_dims`, `exactly_one_angle_rad`, `at_most_one_angle_rad`
  (error messages passed per-call to preserve exact wording).

## Verification

- `cargo build --release` (default + `image`) and `cd python && cargo build`:
  **0 errors, 0 warnings**.
- Unit: **48 passed, 0 failed**.
- Integration (skyview / tess / integration): **5(+1 ignored) / 1 / 3, 0 failures**.

## Notes

- Several solver files mix dead-code/API/dedup/perf changes in the same hunks, so
  commits are split along the natural seam (Rust core vs Python bindings) rather
  than forcing finer, non-compiling intermediates.
- A couple of candidate cleanups were intentionally **declined** (documented in #33):
  unifying the two greedy matchers (differ in precision/boundary/dedup), and a
  global `pixel_scale_from_fov` (heterogeneous f32/f64/`max(1)` sites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
