### PR TITLE
release: 0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.7.3
 
 ### New features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,7 +890,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tetra3"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "image",
  "numeris",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "tetra3-python"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "numeris",
  "numpy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = [
     "pattern-recognition",
 ]
 name = "tetra3"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 description = "Rust implementation of Tetra3: Fast and robust star plate solver"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tetra3rs"
-version = "0.7.2"
+version = "0.7.3"
 description = "Fast star plate solver written in Rust"
 requires-python = ">=3.10"
 dependencies = ["numpy", "gaia-catalog<1.0"]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tetra3-python"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
Release 0.7.3. Bumps version across all three files (`Cargo.toml`, `pyproject.toml`, `python/Cargo.toml`) and retitles the CHANGELOG `Unreleased` section to `0.7.3`.

## Highlights
- **New:** optional `parallel` cargo feature — multi-threaded centroid extraction (~1.9× sparse / ~1.45× dense on 8 cores, bit-identical output). Build with `--features image,parallel`.
- **Performance:** behavior-identical solver speedups (parity-flip rotation without a second SVD; `wcs_refine` allocation hoisting).
- **Internal:** numeris 0.5.11 → 0.5.12.

After merge: tag `v0.7.3` (triggers PyPI wheel build) and `cargo publish -p tetra3` for crates.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)