### PR TITLE
Release 0.8.0: fast single-pass centroider + geometric-center origin fix (#28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## Unreleased
 
+## 0.8.0
+
+> **Note on serialized artifacts.** 0.8.0 changes the on-the-wire format of
+> several public types, so binary databases and pickles saved by 0.7.x do not
+> load: `SolveResult` (now `Result<Solution, SolveFailure>`) and any
+> `RadialDistortion` / `CameraModel` (new `RadialDistortion::center` field).
+> Regenerate databases and re-pickle results after upgrading.
+
+### Added
+
+- **Fast single-pass centroid extractor — an "adequate star tracker" path.**
+  `extract_centroids_fast` (Rust + Python) / `FastCentroidConfig` reads each
+  pixel once: a cheap subsampled pre-pass builds a coarse background grid, then
+  a single raster sweep thresholds against the interpolated background and
+  groups lit pixels into connected regions via run-length + union-find,
+  accumulating intensity-weighted moments inline and emitting one center-of-mass
+  per region (with an optional 3×3 parabola peak refine). No convolution and no
+  second pass, so it is memory-bandwidth-bound: **~4–5× faster** than the
+  connected-component path single-threaded on 2048² TESS frames (~26–32 ms vs
+  ~126 ms), with equal solve accuracy and ~0.1 px centroid agreement on bright
+  stars. It trades faint-star sensitivity and tight sub-pixel accuracy for
+  speed; `extract_centroids` / `extract_centroids_from_raw` stay the default and
+  the right choice for calibration and faint-star work. Returns the same
+  `ExtractionResult`, so it is a drop-in for `solve_from_centroids`.
+
 ### Changed
 
 - **Radial calibration rewritten as a standard camera-intrinsics fit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,21 @@
 
 ### Changed
 
+- **Centroid origin moved to the geometric image center `(W−1)/2`, `(H−1)/2`
+  (was `W/2`, `H/2`).** Pixel centers sit at integer indices, so the geometric
+  center — the intersection of the four central pixels for even dimensions, the
+  middle pixel for odd — is at `(W−1)/2`, a half-pixel left of and above the old
+  origin. This matches the FITS / astropy / astrometry.net / OpenCV convention,
+  removing a ~½-pixel (~130–250″ on a wide-field camera) bias when comparing
+  tetra3rs solutions against those tools or feeding them a `crpix` derived from
+  one. The old origin was internally consistent, so tetra3rs-only solves were
+  not biased; returned centroid coordinates and the boresight now shift by half
+  a pixel toward the geometric center. Applies to `extract_centroids`,
+  `extract_centroids_fast`, and any caller-supplied centroids (which should now
+  use the `(W−1)/2` origin). The docs' coordinate page now also states
+  explicitly that the solved attitude is the direction at the **center pixel**,
+  not the optical/distortion axis. (Issue #28.)
+
 - **Radial calibration rewritten as a standard camera-intrinsics fit
   (OpenCV-style).** `calibrate_camera(model = Radial)` now jointly fits the
   optical-axis position `(cx, cy)`, a focal-scale factor `γ`, and the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,7 +890,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tetra3"
-version = "0.7.4"
+version = "0.8.0"
 dependencies = [
  "image",
  "numeris",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "tetra3-python"
-version = "0.7.4"
+version = "0.8.0"
 dependencies = [
  "numeris",
  "numpy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = [
     "pattern-recognition",
 ]
 name = "tetra3"
-version = "0.7.4"
+version = "0.8.0"
 edition = "2021"
 description = "Rust implementation of Tetra3: Fast and robust star plate solver"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -14,33 +14,7 @@ Given a set of star centroids extracted from a camera image, tetra3rs identifies
 **Documentation:** For tutorials, concept guides, and Python API reference, see the [tetra3rs documentation](https://tetra3rs.dev/). For Rust API docs, see [docs.rs](https://docs.rs/tetra3).
 
 > [!IMPORTANT]
-> **Status: Alpha** — The core solver is based on well-vetted algorithms but has only been tested against a limited set of images. The API is not yet stable and may change between releases.  Having said that, I've made it work on both low-SNR images taken with a camera in my backyard and with high-star-density images from more-complex telescopes.
-
-> [!CAUTION]
-> **Database format change in 0.7.0 — older databases will not load.**
-> The solver database serialization format moved from rkyv to
-> [postcard](https://docs.rs/postcard) and the on-disk extension changed
-> from `.rkyv` to `.bin`. **Existing `.rkyv` files saved by 0.6.x or
-> earlier — both `SolverDatabase` and `CameraModel` — must be
-> regenerated.** Pickled `tetra3rs` objects from older wheels will also
-> fail to unpickle.
->
-> Regenerate solver databases with `SolverDatabase::generate_from_gaia(...)`
-> in Rust, or `tetra3rs.SolverDatabase.generate_from_gaia(...)` in Python.
-> The bundled [`gaia-catalog`](https://pypi.org/project/gaia-catalog/)
-> PyPI package handles this transparently for Python users — first solve
-> after upgrading regenerates the cached database automatically.
-
-> [!WARNING]
-> **Other 0.7.0 breaking changes.** The Rust `SolverDatabase::pattern_catalog`
-> field is now a flat `PatternCatalog` (the rkyv-era sharding workaround
-> was removed); `RadialDistortion` gained `p1, p2` tangential coefficients
-> (full Brown-Conrady); `CalibrateConfig::polynomial_order` was replaced
-> by `model: DistortionModelType`; the public Rust function
-> `extract_centroids(path, ...)` was removed in favor of
-> `extract_centroids_from_image(...)`. See [CHANGELOG.md](CHANGELOG.md)
-> for the full list.
-
+> **Status: Alpha** — The core solver is based on well-vetted algorithms and has been validated against both real low-SNR images taken with a camera in my backyard and high-star-density images from more-complex telescopes (plus synthetic SkyView and NASA TESS multi-sector data). The API is not yet stable and may change between releases. See [CHANGELOG.md](CHANGELOG.md) for breaking changes per release.
 
 ## Features
 
@@ -53,7 +27,7 @@ Given a set of star centroids extracted from a camera image, tetra3rs identifies
 - **Compact binary databases** — databases serialize with [postcard](https://docs.rs/postcard) in a portable, lightweight format with no offset-size limit, so wide-FOV-range multiscale databases of any size load cleanly
 - **Centroid extraction** — detect stars from in-memory pixel data with local background subtraction, connected-component labeling, and quadratic sub-pixel peak refinement. Accepts an already-decoded `image::DynamicImage` or a raw `&[f32]` pixel buffer (requires the `image` feature)
 - **Camera model** — unified intrinsics struct (focal length, optical center, parity, distortion) used throughout the pipeline
-- **Distortion calibration** — fit either a SIP polynomial or a Brown-Conrady radial `(k1, k2, k3)` distortion model from one or more solved images via `calibrate_camera`, with alternating per-image WCS refinement and global LS fit (the OpenCV / Zhang's-method shape for radial)
+- **Distortion calibration** — fit either a SIP polynomial or a standard camera-intrinsics model (free optical center, focal scale, and full Brown-Conrady `k1, k2, k3, p1, p2` — the same parameter set as OpenCV's `calibrateCamera`) from one or more solved images via `calibrate_camera`, with alternating per-image WCS refinement and global sigma-clipped LS fit. Handles mosaic cameras (e.g. TESS) where the optical axis sits far off the detector
 - **WCS output** — solve results include FITS-standard WCS fields (CD matrix, CRVAL) and pixel↔sky coordinate conversion methods
 - **Stellar aberration** — optional correction for the ~20" apparent shift in star positions caused by the observer's barycentric velocity, with a built-in convenience function for Earth's barycentric velocity
 
@@ -84,7 +58,7 @@ pip install .
 
 
 > [!NOTE]
-> All Python objects (`SolverDatabase`, `CameraModel`, `SolveResult`, `CalibrateResult`, `ExtractionResult`, `Centroid`, `RadialDistortion`, `PolynomialDistortion`) support `pickle` serialization via [postcard](https://docs.rs/postcard).
+> All Python objects (`SolverDatabase`, `CameraModel`, `SolveResult`, `SolveFailure`, `CalibrateResult`, `ExtractionResult`, `Centroid`, `RadialDistortion`, `PolynomialDistortion`) support `pickle` serialization via [postcard](https://docs.rs/postcard).
 
 ## Quick start
 

--- a/docs/api/extraction.md
+++ b/docs/api/extraction.md
@@ -2,6 +2,8 @@
 
 ::: tetra3rs.extract_centroids
 
+::: tetra3rs.extract_centroids_fast
+
 ::: tetra3rs.ExtractionResult
 
 ::: tetra3rs.Centroid

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -15,7 +15,8 @@ Python API documentation for tetra3rs, auto-generated from type stubs.
 
 | Symbol | Description |
 |--------|-------------|
-| [`extract_centroids()`](extraction.md) | Extract star centroids from an image array |
+| [`extract_centroids()`](extraction.md) | Extract star centroids from an image array (connected-component pipeline; default) |
+| [`extract_centroids_fast()`](extraction.md#tetra3rs.extract_centroids_fast) | Fast single-pass extractor — lower latency, lower fidelity ("adequate star tracker") |
 | [`ExtractionResult`](extraction.md#tetra3rs.ExtractionResult) | Extraction result with centroids and image statistics |
 | [`Centroid`](extraction.md#tetra3rs.Centroid) | A single star centroid with position, brightness, and shape |
 

--- a/docs/concepts/camera-model.md
+++ b/docs/concepts/camera-model.md
@@ -9,7 +9,7 @@ The `CameraModel` encapsulates the mapping between pixel coordinates and tangent
 | `focal_length_px` | Focal length in pixels (= image_width / (2 × tan(FOV/2))) |
 | `image_width` | Image width in pixels |
 | `image_height` | Image height in pixels |
-| `crpix` | Optical center offset from image center `[x, y]` in pixels |
+| `crpix` | Projection-origin offset from the geometric image center `[x, y]` in pixels (default `[0, 0]`; *not* the distortion/optical center) |
 | `parity_flip` | Whether the image x-axis is mirrored |
 | `distortion` | Optional `RadialDistortion` or `PolynomialDistortion` model |
 

--- a/docs/concepts/centroid-extraction.md
+++ b/docs/concepts/centroid-extraction.md
@@ -2,6 +2,15 @@
 
 tetra3rs includes a complete centroid extraction pipeline that detects stars in an image and computes sub-pixel positions with uncertainty estimates. The pipeline is designed to be robust across a range of conditions — from low-SNR ground-based images to crowded spacecraft fields.
 
+!!! tip "Two extractors"
+    This page describes the default **connected-component pipeline**
+    (`extract_centroids` / `extract_centroids_from_raw`), which prioritizes
+    fidelity. For latency-critical use (e.g. frame-rate tracking on embedded
+    hardware) there is also a **fast single-pass extractor**
+    (`extract_centroids_fast`), ~4–5× faster at lower fidelity — see
+    [Fast single-pass extraction](#fast-single-pass-extraction-extract_centroids_fast)
+    below.
+
 ## Pipeline Overview
 
 ```
@@ -139,11 +148,13 @@ Otherwise, the center-of-mass position is kept. This fallback ensures robustness
 
 ## 7. Output
 
-Centroids are converted to **image-center origin** coordinates:
+Centroids are converted to **geometric-image-center origin** coordinates
+(pixel centers at integer indices, so the center is `(W−1)/2`, `(H−1)/2` —
+matching FITS / astropy / OpenCV; see [Coordinate Conventions](coordinates.md)):
 
 $$
-x_{\text{out}} = x_{\text{px}} - \frac{W}{2}, \qquad
-y_{\text{out}} = y_{\text{px}} - \frac{H}{2}
+x_{\text{out}} = x_{\text{px}} - \frac{W-1}{2}, \qquad
+y_{\text{out}} = y_{\text{px}} - \frac{H-1}{2}
 $$
 
 where $W$ and $H$ are the image dimensions. The coordinate convention is +X right, +Y down — the same as the camera frame used by the solver. See [Coordinate Conventions](coordinates.md) for details.
@@ -173,7 +184,69 @@ typical fields — is left sequential, as is connected-component labeling (step
 
 Build with `cargo build --release --features image,parallel`.
 
-## Configuration Reference
+## Fast single-pass extraction (`extract_centroids_fast`)
+
+The pipeline above prioritizes fidelity — local-background interpolation, an
+optional matched filter, full connected-component analysis, per-blob annulus
+backgrounds, and shape/elongation gating. For latency-critical applications
+(frame-rate tracking, embedded star trackers) tetra3rs offers an alternative
+that reads each pixel **once**: `extract_centroids_fast`
+(`FastCentroidConfig` in Rust). It is an *additive* alternative — the
+connected-component path stays the default and the right choice for
+calibration and faint-star work.
+
+### Algorithm
+
+1. **Coarse background pre-pass.** A subsampled grid (~1/64 of the pixels)
+   gives a `bg_grid`-spaced background grid and a global noise σ. Cheap, and
+   still tracks large-scale gradients (vignetting, Milky Way).
+2. **Single raster sweep.** Each pixel is thresholded against the bilinearly
+   interpolated background (`> bg + sigma_threshold·σ`). Lit pixels are grouped
+   into connected regions on the fly via **run-length + union-find**, with
+   intensity-weighted moments accumulated inline. One center-of-mass is emitted
+   per region, with the same 3×3 quadratic peak refinement as the main pipeline
+   (gated to agree with the CoM).
+
+No convolution and no second pass, so the cost is dominated by a single memory
+read rather than compute.
+
+### Speed and accuracy
+
+On 2048×2048 TESS frames, single-threaded: **~26–32 ms vs ~126 ms** for the
+connected-component path — **~4–5× faster** — with equal end-to-end solve
+accuracy and ~**0.1 px** centroid agreement on bright stars.
+
+The trade-offs are deliberate:
+
+- **No matched filter**, so faint-star sensitivity is lower — sized for the
+  brightest stars a tracker locks onto, not deep detection.
+- **Center-of-mass is threshold-clipped**: sub-pixel accuracy is ~0.1 px on
+  bright stars, degrading for faint ones. Use the connected-component path
+  for calibration / tight astrometry.
+- A **global noise σ** is used (adequate when read/shot noise is roughly
+  uniform even where the background *level* varies).
+
+It returns the same `ExtractionResult` (center-origin coordinates, brightest
+first), so it is a drop-in for `solve_from_centroids`.
+
+### Configuration
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `sigma_threshold` | 5.0 | Detection threshold in noise σ above the local background |
+| `bg_grid` | 64 | Coarse background-grid block size (pixels) |
+| `min_pixels` | 2 | Minimum pixels in a region (rejects hot pixels) |
+| `max_centroids` | None | Maximum centroids to return, brightest first (None = all) |
+
+```python
+result = tetra3rs.extract_centroids_fast(image, sigma_threshold=5.0, max_centroids=30)
+solution = db.solve_from_centroids(result.centroids, camera_model=cam)
+```
+
+## Configuration Reference (connected-component pipeline)
+
+These parameters configure the default `extract_centroids` pipeline (the fast
+path's knobs are listed [above](#configuration)).
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|

--- a/docs/concepts/coordinates.md
+++ b/docs/concepts/coordinates.md
@@ -10,29 +10,77 @@ tetra3rs uses a right-handed camera frame:
 
 ## Pixel Coordinates
 
-All pixel coordinates use the **image center as origin**:
+All pixel coordinates use the **geometric image center as the origin**.
 
-- `x = 0, y = 0` is the geometric center of the image
-- `+X` is to the right
-- `+Y` is downward
+Pixel *centers* sit at integer indices (a single bright pixel at column `c`,
+row `r` produces a centroid at `x_px = c`, `y_px = r` before centering), so for
+an image `W` pixels wide and `H` pixels tall the geometric center is at
+
+$$
+(c_x,\;c_y) = \left(\frac{W-1}{2},\;\frac{H-1}{2}\right),
+$$
+
+and the centered coordinates handed to / returned by the solver are
+`x = c − (W−1)/2`, `y = r − (H−1)/2`:
+
+- `x = 0, y = 0` is the geometric center of the image.
+- For **even** dimensions this is the intersection of the four central pixels
+  (e.g. for `W = 3840`, `c_x = 1919.5`, between columns 1919 and 1920).
+- For **odd** dimensions it is the center of the single middle pixel.
+- `+X` is to the right, `+Y` is downward.
+
+This matches the geometric-center convention used by **FITS WCS, astropy,
+astrometry.net, OpenCV, and scikit-image** (FITS' 1-indexed center
+`(W+1)/2` is the same point as the 0-indexed `(W−1)/2`), so a `crpix` taken
+from any of those tools can be used directly.
 
 This applies to:
 
 - Input centroids (both `Centroid` objects and numpy arrays)
 - `SolveResult.pixel_to_world()` / `world_to_pixel()` inputs and outputs
-- `ExtractionResult.centroids` returned by `extract_centroids()`
+- `ExtractionResult.centroids` returned by `extract_centroids()` and
+  `extract_centroids_fast()`
 
-!!! note
-    This convention differs from many image processing libraries where the origin is at the top-left corner. If your centroids use a top-left origin, subtract `(image_width/2, image_height/2)` before passing them to the solver.
+!!! note "Centered origin — not a corner origin"
+    tetra3rs always uses a **center origin**: the boresight, the gnomonic
+    projection, and the distortion field are all symmetric about the image
+    center, so that is the natural reference for pointing geometry. This
+    differs from image-processing libraries (numpy, OpenCV indexing), which
+    use a **top-left corner** origin with the first pixel center at `(0, 0)`
+    because it suits raster array access, not pointing.
 
-## CRPIX — Optical Center Offset
+    You only deal with the corner convention at the *input* boundary: if your
+    centroids are corner-indexed (e.g. raw detector row/column), subtract
+    `((W−1)/2, (H−1)/2)` to convert them to the center origin before passing
+    them to the solver. `extract_centroids()` /
+    `extract_centroids_fast()` already return center-origin coordinates.
 
-The optical center of a real camera may not coincide with the geometric image center. The `crpix` parameter in `CameraModel` represents this offset:
+!!! warning "Changed in 0.8.0"
+    Earlier versions placed the origin at `(W/2, H/2)` — a half-pixel right of
+    and below the geometric center. 0.8.0 moved it to `((W−1)/2, (H−1)/2)` to
+    match the FITS / astropy / OpenCV convention. This removes a ~½-pixel bias
+    when comparing tetra3rs solutions against those tools (it was internally
+    consistent, so it never biased tetra3rs-only solves). See issue #28.
 
-- `crpix = [0, 0]` means the optical center is at the image center (default)
-- `crpix = [dx, dy]` means the optical center is shifted by `(dx, dy)` pixels from the image center
+## CRPIX — projection reference offset
 
-The solver subtracts `crpix` from pixel coordinates before applying the projection.
+`crpix` in `CameraModel` shifts the **projection origin** away from the
+geometric image center:
+
+- `crpix = [0, 0]` (default) puts the projection origin at the geometric
+  center, so the boresight (+Z) is the sky direction imaged at the center
+  pixel.
+- `crpix = [dx, dy]` moves the projection origin by `(dx, dy)` pixels; the
+  solver subtracts `crpix` from each pixel coordinate before projecting.
+
+!!! note "`crpix` is not the distortion center"
+    `crpix` is the tangent-plane projection origin. The **optical axis** —
+    where lens (radial/tangential) distortion is physically centered — is a
+    separate quantity, carried by `RadialDistortion::center`. On mosaic
+    cameras (TESS, Kepler, …) the optical axis can lie far off the detector
+    (near a CCD corner), while `crpix` stays near the image center so the
+    solver's FOV-radius queries and pattern geometry remain valid. See the
+    [camera model](camera-model.md) page.
 
 ## Sky Coordinates (ICRS)
 
@@ -46,7 +94,23 @@ Solved attitudes are in the International Celestial Reference System (ICRS):
 
 The solved attitude is available as:
 
-- A **3×3 rotation matrix** (`rotation_matrix_icrs_to_camera`) mapping ICRS unit vectors to camera-frame unit vectors
-- Decomposed **RA, Dec, Roll** angles
+- A **3×3 rotation matrix** (`rotation_matrix_icrs_to_camera`) mapping ICRS
+  unit vectors to camera-frame unit vectors.
+- Decomposed **RA, Dec, Roll** angles.
+- In the Rust API, a `UnitQuaternion` (`qicrs2cam`).
 
-In the Rust API, the attitude is also available as a `UnitQuaternion` (`qicrs2cam`).
+### What the attitude points at
+
+The solved attitude's boresight — camera **+Z**, equivalently the reported
+**RA/Dec** — is the sky direction that images onto the **projection origin**:
+the center pixel `((W−1)/2, (H−1)/2)` when `crpix = [0, 0]`, or the `crpix`
+location when set.
+
+!!! important "Center pixel, not the optical boresight"
+    +Z points at the sky direction landing on the **center pixel**, *not* at
+    the camera's optical/lens axis. On a real camera the optical axis (the
+    distortion center, `RadialDistortion::center`) generally falls on a
+    *different* pixel, so it corresponds to a slightly different sky
+    direction. tetra3rs always reports the attitude of the center-pixel
+    boresight; if you need the pointing of the optical axis, project that
+    pixel through `pixel_to_world()`.

--- a/docs/concepts/wcs.md
+++ b/docs/concepts/wcs.md
@@ -9,7 +9,7 @@ Every successful solve produces FITS-standard World Coordinate System (WCS) fiel
 | `cd_matrix` | 2×2 CD matrix (tangent-plane radians per pixel) |
 | `crval_ra_deg` | RA of the WCS reference point (degrees) |
 | `crval_dec_deg` | Dec of the WCS reference point (degrees) |
-| `crpix` | Optical center offset from image center `[x, y]` (pixels) |
+| `crpix` | Projection-origin offset from the geometric image center `[x, y]` (pixels; default `[0, 0]`) |
 
 The WCS uses a **gnomonic (TAN) projection** centered at `(CRVAL_RA, CRVAL_DEC)`.
 
@@ -21,7 +21,7 @@ $$
 \begin{pmatrix} \xi \\ \eta \end{pmatrix} = \mathbf{CD} \cdot \begin{pmatrix} \Delta x \\ \Delta y \end{pmatrix}
 $$
 
-where $\xi$ and $\eta$ are gnomonic tangent-plane coordinates in radians, and $(\Delta x, \Delta y)$ are pixel offsets from the optical center.
+where $\xi$ and $\eta$ are gnomonic tangent-plane coordinates in radians, and $(\Delta x, \Delta y)$ are pixel offsets from the projection origin (`crpix`, i.e. the geometric image center by default).
 
 The CD matrix encodes pixel scale, rotation, and any skew. For a camera with uniform pixel scale and no skew, the CD matrix elements give:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tetra3rs"
-version = "0.7.4"
+version = "0.8.0"
 description = "Fast star plate solver written in Rust"
 requires-python = ">=3.10"
 dependencies = ["numpy", "gaia-catalog<1.0"]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tetra3-python"
-version = "0.7.4"
+version = "0.8.0"
 edition = "2021"
 publish = false
 

--- a/python/src/extraction.rs
+++ b/python/src/extraction.rs
@@ -2,7 +2,7 @@ use numpy::PyReadonlyArray2;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 
-use tetra3::centroid_extraction::CentroidExtractionConfig;
+use tetra3::centroid_extraction::{CentroidExtractionConfig, FastCentroidConfig};
 
 use crate::centroid::PyCentroid;
 
@@ -243,6 +243,78 @@ pub(crate) fn extract_centroids(
 
     let result =
         tetra3::centroid_extraction::extract_centroids_from_raw(&pixels, width, height, &config)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+
+    let py_centroids: Vec<PyCentroid> = result
+        .centroids
+        .into_iter()
+        .map(|c| PyCentroid { inner: c })
+        .collect();
+
+    Ok(PyExtractionResult {
+        centroids: py_centroids,
+        image_width: width,
+        image_height: height,
+        background_mean: result.background_mean as f64,
+        background_sigma: result.background_sigma as f64,
+        threshold: result.threshold as f64,
+        num_blobs_raw: result.num_blobs_raw,
+    })
+}
+
+/// Fast single-pass centroid extraction — the "adequate star tracker" path.
+///
+/// Reads each pixel once: a cheap subsampled pre-pass builds a coarse
+/// background grid, then a single raster sweep thresholds against the
+/// interpolated background and groups lit pixels into connected regions
+/// (run-length + union-find), emitting one center-of-mass per region. No
+/// convolution and no second pass, so it is several times faster than
+/// :func:`extract_centroids` — at the cost of faint-star sensitivity and
+/// sub-pixel accuracy (~0.1 px on bright stars). Use :func:`extract_centroids`
+/// for calibration or faint-star work.
+///
+/// Returns the same ``ExtractionResult`` as :func:`extract_centroids`, so it
+/// is a drop-in for ``solve_from_centroids``.
+///
+/// Args:
+///     image: 2D numpy array (height x width) of pixel values.
+///         Supported dtypes: float64, float32, uint16, int16, uint8.
+///     sigma_threshold: Detection threshold in noise sigmas above the local
+///         background. Default 5.0.
+///     bg_grid: Coarse background-grid block size in pixels. Gradients
+///         (vignetting, Milky Way) are tracked via this grid. Default 64.
+///     min_pixels: Minimum pixels in a region (rejects hot pixels). Default 2.
+///     max_centroids: Maximum number of centroids to return, brightest first.
+///         None = all. A few dozen is plenty for solving / tracking.
+///
+/// Returns:
+///     ExtractionResult with centroids and image statistics.
+#[pyfunction]
+#[pyo3(signature = (
+    image,
+    sigma_threshold = 5.0,
+    bg_grid = 64,
+    min_pixels = 2,
+    max_centroids = None,
+))]
+pub(crate) fn extract_centroids_fast(
+    image: &Bound<'_, pyo3::PyAny>,
+    sigma_threshold: f32,
+    bg_grid: u32,
+    min_pixels: usize,
+    max_centroids: Option<usize>,
+) -> PyResult<PyExtractionResult> {
+    let (pixels, width, height) = image_to_f32(image)?;
+
+    let config = FastCentroidConfig {
+        sigma_threshold,
+        bg_grid,
+        min_pixels,
+        max_centroids,
+    };
+
+    let result =
+        tetra3::centroid_extraction::extract_centroids_fast(&pixels, width, height, &config)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
 
     let py_centroids: Vec<PyCentroid> = result

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -32,6 +32,7 @@ fn tetra3rs(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<distortion::PyRadialDistortion>()?;
     m.add_class::<distortion::PyPolynomialDistortion>()?;
     m.add_function(wrap_pyfunction!(extraction::extract_centroids, m)?)?;
+    m.add_function(wrap_pyfunction!(extraction::extract_centroids_fast, m)?)?;
     m.add_function(wrap_pyfunction!(earth_barycentric_velocity, m)?)?;
     m.add("__git_hash__", env!("TETRA3RS_GIT_HASH"))?;
     Ok(())

--- a/python/src/solver_database.rs
+++ b/python/src/solver_database.rs
@@ -121,6 +121,18 @@ impl PySolverDatabase {
 
     /// Solve for camera attitude given star centroids.
     ///
+    /// Runs **lost-in-space** (pattern-hash search) by default, or **tracking**
+    /// (direct correspondence from a prior estimate) when ``attitude_hint`` is
+    /// given — with automatic fallback to lost-in-space. Arguments group by
+    /// which mode reads them; arguments for one mode are ignored in the other:
+    ///
+    /// * **Both modes:** ``camera_model`` / ``fov_estimate_*`` / ``image_*``,
+    ///   ``match_radius``, ``match_threshold``, ``solve_timeout_ms``,
+    ///   ``observer_velocity_km_s``.
+    /// * **Lost-in-space only:** ``fov_max_error``, ``match_max_error``.
+    /// * **Tracking only** (ignored unless ``attitude_hint`` is set):
+    ///   ``attitude_hint``, ``hint_uncertainty_*``, ``strict_hint``.
+    ///
     /// Args:
     ///     centroids: Either a list of Centroid objects (from extract_centroids),
     ///         or an Nx2/Nx3 numpy array of centroid positions in pixels.

--- a/python/tests/test_basic.py
+++ b/python/tests/test_basic.py
@@ -34,7 +34,11 @@ class TestImport:
             assert hasattr(tetra3rs, name), f"Missing: {name}"
 
     def test_all_functions_exist(self):
-        for name in ["earth_barycentric_velocity", "extract_centroids"]:
+        for name in [
+            "earth_barycentric_velocity",
+            "extract_centroids",
+            "extract_centroids_fast",
+        ]:
             assert callable(getattr(tetra3rs, name)), f"Not callable: {name}"
 
 
@@ -390,6 +394,48 @@ class TestExtractCentroids:
         image[32, 32] = 10000  # bright pixel
 
         result = tetra3rs.extract_centroids(image, sigma_threshold=3.0)
+        result2 = pickle.loads(pickle.dumps(result))
+        assert result2.image_width == result.image_width
+        assert len(result2.centroids) == len(result.centroids)
+
+    def test_fast_gaussian_spots(self):
+        """The single-pass fast path recovers spots over a gradient."""
+        h, w = 512, 512
+        # Background with a left-to-right gradient + noise.
+        gradient = np.linspace(50, 250, w, dtype=np.float32)[None, :]
+        image = (np.random.normal(0, 5, (h, w)) + gradient).astype(np.float32)
+
+        spots = [(100, 200), (300, 150), (250, 400), (50, 50), (450, 300)]
+        for cy, cx in spots:
+            yy, xx = np.mgrid[cy - 10 : cy + 11, cx - 10 : cx + 11]
+            yy = np.clip(yy, 0, h - 1)
+            xx = np.clip(xx, 0, w - 1)
+            g = 5000 * np.exp(-((yy - cy) ** 2 + (xx - cx) ** 2) / (2 * 2.0**2))
+            image[yy, xx] += g.astype(np.float32)
+
+        result = tetra3rs.extract_centroids_fast(
+            image, sigma_threshold=5.0, bg_grid=64, max_centroids=20
+        )
+        assert isinstance(result, tetra3rs.ExtractionResult)
+        assert result.image_width == w and result.image_height == h
+        assert result.background_sigma > 0
+        assert len(result.centroids) >= 3
+
+        # Brightest of the 5 injected spots should be recovered to ~1 px.
+        found = [(c.x + w / 2, c.y + h / 2) for c in result.centroids]
+        for cy, cx in spots:
+            nearest = min(((fx - cx) ** 2 + (fy - cy) ** 2) ** 0.5 for fx, fy in found)
+            assert nearest < 1.0, f"spot ({cx},{cy}) nearest detection {nearest:.2f} px"
+
+    def test_fast_result_pickle_and_drop_in(self):
+        """Fast path returns a pickleable ExtractionResult with usable centroids."""
+        h, w = 64, 64
+        image = np.random.normal(100, 5, (h, w)).astype(np.float32)
+        image[32, 32] = 10000
+        image[31, 32] = 8000  # 2-pixel region so min_pixels=2 keeps it
+
+        result = tetra3rs.extract_centroids_fast(image, sigma_threshold=4.0)
+        assert len(result.centroids) >= 1
         result2 = pickle.loads(pickle.dumps(result))
         assert result2.image_width == result.image_width
         assert len(result2.centroids) == len(result.centroids)

--- a/python/tests/test_tess.py
+++ b/python/tests/test_tess.py
@@ -107,10 +107,12 @@ class TestTessMultiImageCalibration:
             # Compare center pixel against FITS WCS
             solved_ra, solved_dec = result.pixel_to_world(0.0, 0.0)
 
-            # FITS WCS reference: center of the 2048x2048 science region
-            # in full-frame coords is (44 + 1024, 1024)
+            # FITS WCS reference: geometric center of the 2048x2048 science
+            # region (pixel-center origin (W-1)/2, issue #28) in full-frame
+            # 0-indexed coords is (44 + 1023.5, 1023.5) — matching the origin of
+            # pixel_to_world(0, 0) above.
             wcs_ra, wcs_dec = fits_pixel_to_radec(
-                headers, 44.0 + sci_size / 2.0, sci_size / 2.0
+                headers, 44.0 + (sci_size - 1) / 2.0, (sci_size - 1) / 2.0
             )
             sep = angular_sep_deg(solved_ra, solved_dec, wcs_ra, wcs_dec) * 3600
 
@@ -257,8 +259,9 @@ class TestTessMultiImageCalibration:
         for result, headers, sector in zip(results, all_headers, sectors):
             rmse = result.rmse_arcsec
             solved_ra, solved_dec = result.pixel_to_world(0.0, 0.0)
+            # Geometric center (W-1)/2 (issue #28), matching pixel_to_world(0, 0).
             wcs_ra, wcs_dec = fits_pixel_to_radec(
-                headers, 44.0 + sci_size / 2.0, sci_size / 2.0
+                headers, 44.0 + (sci_size - 1) / 2.0, (sci_size - 1) / 2.0
             )
             sep = angular_sep_deg(solved_ra, solved_dec, wcs_ra, wcs_dec) * 3600
             print(

--- a/python/tetra3rs/__init__.pyi
+++ b/python/tetra3rs/__init__.pyi
@@ -1121,6 +1121,38 @@ def extract_centroids(
     """
     ...
 
+def extract_centroids_fast(
+    image: npt.NDArray,
+    sigma_threshold: float = 5.0,
+    bg_grid: int = 64,
+    min_pixels: int = 2,
+    max_centroids: Optional[int] = None,
+) -> ExtractionResult:
+    """Fast single-pass centroid extraction — the "adequate star tracker" path.
+
+    Reads each pixel once (coarse-grid background + run-length connected-
+    component moments), so it is several times faster than
+    :func:`extract_centroids` — at the cost of faint-star sensitivity and
+    sub-pixel accuracy (~0.1 px on bright stars). Use :func:`extract_centroids`
+    for calibration or faint-star work. Returns the same ``ExtractionResult``,
+    so it is a drop-in for ``solve_from_centroids``.
+
+    Args:
+        image: 2D numpy array (height x width) of pixel values.
+            Supported dtypes: float64, float32, uint16, int16, uint8.
+        sigma_threshold: Detection threshold in noise sigmas above the local
+            background.
+        bg_grid: Coarse background-grid block size in pixels (tracks gradients
+            such as vignetting / Milky Way).
+        min_pixels: Minimum pixels in a region; rejects hot pixels.
+        max_centroids: Maximum number of centroids to return, brightest first.
+            None = all.
+
+    Returns:
+        ExtractionResult with centroids and image statistics.
+    """
+    ...
+
 def undistort_centroids(
     centroids: list[Centroid],
     distortion: Union[RadialDistortion, PolynomialDistortion],

--- a/python/tetra3rs/__init__.pyi
+++ b/python/tetra3rs/__init__.pyi
@@ -683,6 +683,18 @@ class SolverDatabase:
     ) -> Union[SolveResult, SolveFailure]:
         """Solve for camera attitude given star centroids.
 
+        Runs **lost-in-space** (pattern-hash search) by default, or **tracking**
+        (direct correspondence from a prior estimate) when ``attitude_hint`` is
+        given — with automatic fallback to lost-in-space. The arguments group by
+        which mode reads them; arguments for one mode are ignored in the other:
+
+        * **Both modes:** ``camera_model`` / ``fov_estimate_*`` / ``image_*``,
+          ``match_radius``, ``match_threshold``, ``solve_timeout_ms``,
+          ``observer_velocity_km_s``.
+        * **Lost-in-space only:** ``fov_max_error_*``, ``match_max_error``.
+        * **Tracking only** (ignored unless ``attitude_hint`` is set):
+          ``attitude_hint``, ``hint_uncertainty_*``, ``strict_hint``.
+
         Args:
             centroids: Either a list of Centroid objects (from extract_centroids),
                 or an Nx2/Nx3 numpy array of centroid positions in pixels.
@@ -701,11 +713,13 @@ class SolverDatabase:
             fov_max_error_deg: Maximum FOV error in degrees. None = no limit.
             fov_max_error_rad: Maximum FOV error in radians. None = no limit.
                 At most one of fov_max_error_deg or fov_max_error_rad can be provided.
+                Lost-in-space only — tracking takes its scale from the hint.
             match_radius: Match distance as fraction of FOV.
             match_threshold: False-positive probability threshold.
             solve_timeout_ms: Timeout in milliseconds. None = no timeout.
             match_max_error: Maximum edge-ratio error. None = use database value.
                 Values below the database's pattern quantization error are clamped up to it.
+                Lost-in-space only — tracking does not use the pattern hash.
             camera_model: A CameraModel specifying focal length, image
                 dimensions, optical center, distortion, and parity. When
                 provided it is the single source of camera geometry

--- a/src/centroid_extraction.rs
+++ b/src/centroid_extraction.rs
@@ -543,8 +543,9 @@ pub fn extract_centroids_fast(
     }
 
     // ── Emit one centroid per root region ──
-    let cx = width as f32 / 2.0;
-    let cy = height as f32 / 2.0;
+    // Origin at the geometric image center (W-1)/2, (H-1)/2 (see the CCL path).
+    let cx = (width - 1) as f32 / 2.0;
+    let cy = (height - 1) as f32 / 2.0;
     let mut centroids: Vec<Centroid> = Vec::new();
     let mut num_blobs_raw = 0usize;
     for lab in 0..n_labels {
@@ -815,9 +816,12 @@ fn extract_from_gray(
     let num_blobs_raw = raw_centroids.len();
 
     // ── Step 5: convert to centered pixel coordinates ──
-    // Origin at image center, +X right, +Y down
-    let cx = width as f32 / 2.0;
-    let cy = height as f32 / 2.0;
+    // Origin at the geometric image center, (W-1)/2 and (H-1)/2 (pixel centers
+    // are at integer indices, so for even dimensions this is the intersection
+    // of the four central pixels — matching the FITS / astropy / OpenCV
+    // convention). +X right, +Y down.
+    let cx = (width - 1) as f32 / 2.0;
+    let cy = (height - 1) as f32 / 2.0;
 
     let mut centroids: Vec<Centroid> = raw_centroids
         .into_iter()
@@ -1445,8 +1449,8 @@ mod tests {
         // Each true star must have a detection within ~0.6 px. The single-pass
         // path is a ~0.5-px-class centroider by design (threshold-clipped CoM +
         // parabola refine) — plenty for solving, not for tight astrometry.
-        let cx = width as f32 / 2.0;
-        let cy = height as f32 / 2.0;
+        let cx = (width - 1) as f32 / 2.0;
+        let cy = (height - 1) as f32 / 2.0;
         for &(sx, sy, _) in &stars {
             let (tx, ty) = (sx - cx, sy - cy);
             let best = result
@@ -1623,8 +1627,8 @@ mod tests {
 
         // Centroid is in centered coords (origin at image center)
         let c = &result.centroids[0];
-        let cx = width as f32 / 2.0;
-        let cy = height as f32 / 2.0;
+        let cx = (width - 1) as f32 / 2.0;
+        let cy = (height - 1) as f32 / 2.0;
         let abs_x = c.x + cx;
         let abs_y = c.y + cy;
 
@@ -1682,8 +1686,8 @@ mod tests {
         );
 
         // Find the centroid closest to our true position
-        let cx = width as f32 / 2.0;
-        let cy = height as f32 / 2.0;
+        let cx = (width - 1) as f32 / 2.0;
+        let cy = (height - 1) as f32 / 2.0;
         let best = result
             .centroids
             .iter()

--- a/src/centroid_extraction.rs
+++ b/src/centroid_extraction.rs
@@ -11,16 +11,22 @@
 //!
 //! Requires the `image` feature to be enabled.
 //!
-//! Two entry points are provided:
+//! Entry points:
 //! - [`extract_centroids_from_image`] for an already-decoded
 //!   [`image::DynamicImage`]. The caller is responsible for decoding the
 //!   file (using whichever `image` feature flags suit their needs).
 //! - [`extract_centroids_from_raw`] for raw grayscale `f32` pixel data —
 //!   useful for FITS, camera SDK output, or any other non-standard source.
+//! - [`extract_centroids_fast`] is a single-pass "adequate star tracker"
+//!   alternative: it reads each pixel once (coarse-grid background +
+//!   run-length connected-component moments) for markedly lower latency, at
+//!   the cost of faint-star sensitivity and sub-pixel accuracy. The two
+//!   functions above stay the default and the right choice for calibration.
 //!
 //! With the `parallel` feature, the dominant local-background stage and the
-//! full-image element-wise maps run multi-threaded via rayon; results are
-//! bit-identical to the sequential build.
+//! full-image element-wise maps of the connected-component path run
+//! multi-threaded via rayon; results are bit-identical to the sequential
+//! build. (The fast single-pass path is sequential.)
 //!
 //! # Example
 //!
@@ -306,6 +312,416 @@ pub fn extract_centroids_from_raw(
         )));
     }
     extract_from_gray(pixels, width, height, config)
+}
+
+// ─── Fast single-pass star-tracker path ─────────────────────────────────────
+
+/// Configuration for [`extract_centroids_fast`].
+///
+/// Deliberately small — the four knobs a single-pass detector needs. None of
+/// the connected-component path's quality filters (block-interpolated
+/// background, elongation, per-blob annulus background, sub-pixel agreement
+/// gates) appear, because this path trades them away for speed.
+#[derive(Debug, Clone)]
+pub struct FastCentroidConfig {
+    /// Detection threshold in noise sigmas above the local background. A pixel
+    /// is "lit" when `value > bg(x, y) + sigma_threshold · σ`. Default: 5.0
+    pub sigma_threshold: f32,
+
+    /// Coarse background-grid block size in pixels. The background is estimated
+    /// once on a `bg_grid`-spaced grid (from a subsampled pre-pass, ~1/64 the
+    /// pixels) and bilinearly interpolated during the main sweep, so gradients
+    /// (vignetting, Milky Way) are handled without a full-image background
+    /// stage. Larger blocks are cheaper but follow gradients more coarsely.
+    /// Default: 64
+    pub bg_grid: u32,
+
+    /// Minimum pixels in a lit region to count as a star — rejects single hot
+    /// pixels and cosmic-ray specks. Default: 2
+    pub min_pixels: usize,
+
+    /// Maximum number of centroids to return, brightest first. `None` returns
+    /// all detections. For plate solving / tracking a few dozen is plenty.
+    /// Default: None
+    pub max_centroids: Option<usize>,
+}
+
+impl Default for FastCentroidConfig {
+    fn default() -> Self {
+        Self {
+            sigma_threshold: 5.0,
+            bg_grid: 64,
+            min_pixels: 2,
+            max_centroids: None,
+        }
+    }
+}
+
+/// Per-region moment accumulator for the single-pass detector. One per pixel
+/// **run**; runs that connect across rows are merged by union-find at the end.
+#[derive(Clone, Copy)]
+struct Region {
+    parent: u32,
+    sum_w: f64,  // Σ (value − bg), the background-subtracted flux
+    sum_wx: f64, // Σ x·(value − bg)
+    sum_wy: f64, // Σ y·(value − bg)
+    npix: u32,
+    peak_val: f32,
+    peak_x: u32,
+    peak_y: u32,
+}
+
+/// Fast single-pass centroid extraction — the "adequate star tracker" path.
+///
+/// An alternative to [`extract_centroids_from_raw`] that reads each pixel
+/// **once**: a cheap subsampled pre-pass builds a coarse background grid, then
+/// a single raster sweep thresholds against the bilinearly-interpolated
+/// background, groups lit pixels into connected regions via run-length +
+/// union-find (accumulating intensity-weighted moments inline), and emits a
+/// center-of-mass per region. No convolution, no full-image background buffer,
+/// no second pass — so it is memory-bandwidth-bound rather than compute-bound,
+/// and markedly faster than the connected-component path (which stays the
+/// default and the right choice for calibration / faint-star work).
+///
+/// # Trade-offs
+///
+/// - No matched filter, so faint-star sensitivity is lower — sized for the
+///   brightest stars a tracker locks onto, not deep detection.
+/// - Center-of-mass is threshold-clipped: sub-pixel accuracy is ~0.1 px for
+///   bright stars, degrading for faint ones. A 3×3 parabola refine on the peak
+///   ([`quadratic_peak_offset`]) sharpens it when the region is large enough
+///   and the fit agrees with the CoM, matching the CCL path's gate.
+/// - A global noise σ is used (adequate when read/shot noise is roughly
+///   uniform even where the background level is not).
+///
+/// Returns the same [`CentroidExtractionResult`] as the CCL path (centroids in
+/// image-center-origin coordinates, brightest first), so it is a drop-in for
+/// [`SolverDatabase::solve_from_centroids`](crate::SolverDatabase::solve_from_centroids).
+/// `background_mean` is the median of the coarse grid, `background_sigma` the
+/// global noise σ, `threshold` a representative `bg_mean + k·σ`, and
+/// `num_blobs_raw` the region count before the `min_pixels` filter.
+pub fn extract_centroids_fast(
+    pixels: &[f32],
+    width: u32,
+    height: u32,
+    config: &FastCentroidConfig,
+) -> Result<CentroidExtractionResult> {
+    let w = width as usize;
+    let h = height as usize;
+    let expected = w * h;
+    if pixels.len() != expected {
+        return Err(Error::InvalidInput(format!(
+            "Pixel data length ({}) does not match width*height ({}x{}={})",
+            pixels.len(),
+            width,
+            height,
+            expected,
+        )));
+    }
+    if !(config.sigma_threshold.is_finite() && config.sigma_threshold > 0.0) {
+        return Err(Error::InvalidInput(format!(
+            "sigma_threshold must be finite and positive, got {}",
+            config.sigma_threshold
+        )));
+    }
+    if config.bg_grid == 0 {
+        return Err(Error::InvalidInput("bg_grid must be >= 1".into()));
+    }
+    if w < 2 || h < 2 {
+        return Err(Error::InvalidInput("image must be at least 2x2".into()));
+    }
+
+    // ── Pre-pass: coarse background grid + global noise σ (subsampled) ──
+    let block = config.bg_grid as usize;
+    let (bg_grid, nx, ny, sigma) = coarse_background(pixels, w, h, block);
+    let k = config.sigma_threshold;
+
+    // ── Single raster sweep: run-length detection + union-find moments ──
+    let mut regions: Vec<Region> = Vec::new();
+    // Runs of the previous / current row: (col_start, col_end_inclusive, label).
+    let mut prev: Vec<(u32, u32, u32)> = Vec::new();
+    let mut cur: Vec<(u32, u32, u32)> = Vec::new();
+
+    for r in 0..h {
+        cur.clear();
+        let row = r * w;
+        let mut active: Option<(u32, Region)> = None; // (start_col, accumulator)
+
+        for c in 0..w {
+            let bg = bilinear_grid(&bg_grid, nx, ny, block, c, r);
+            let p = pixels[row + c];
+            let lit = p.is_finite() && p > bg + k * sigma;
+
+            if lit {
+                let weight = (p - bg).max(0.0) as f64;
+                // Start a new run only when one isn't already open (building the
+                // Region eagerly every lit pixel would be wasteful).
+                if active.is_none() {
+                    active = Some((
+                        c as u32,
+                        Region {
+                            parent: 0, // set when finalized
+                            sum_w: 0.0,
+                            sum_wx: 0.0,
+                            sum_wy: 0.0,
+                            npix: 0,
+                            peak_val: f32::NEG_INFINITY,
+                            peak_x: c as u32,
+                            peak_y: r as u32,
+                        },
+                    ));
+                }
+                let reg = &mut active.as_mut().unwrap().1;
+                reg.sum_w += weight;
+                reg.sum_wx += weight * c as f64;
+                reg.sum_wy += weight * r as f64;
+                reg.npix += 1;
+                if p > reg.peak_val {
+                    reg.peak_val = p;
+                    reg.peak_x = c as u32;
+                    reg.peak_y = r as u32;
+                }
+            } else if let Some((start, mut reg)) = active.take() {
+                let label = regions.len() as u32;
+                reg.parent = label;
+                regions.push(reg);
+                cur.push((start, c as u32 - 1, label));
+            }
+        }
+        if let Some((start, mut reg)) = active.take() {
+            let label = regions.len() as u32;
+            reg.parent = label;
+            regions.push(reg);
+            cur.push((start, w as u32 - 1, label));
+        }
+
+        // Merge current-row runs with 8-connected previous-row runs. Both lists
+        // are column-sorted, so a two-pointer sweep finds all overlaps.
+        let (mut i, mut j) = (0usize, 0usize);
+        while i < cur.len() && j < prev.len() {
+            let (cs, ce, cl) = cur[i];
+            let (ps, pe, pl) = prev[j];
+            if ce + 1 < ps {
+                i += 1; // current run ends left of (and not adjacent to) prev
+            } else if pe + 1 < cs {
+                j += 1; // prev run ends left of current
+            } else {
+                union(&mut regions, cl, pl);
+                if ce < pe {
+                    i += 1;
+                } else {
+                    j += 1;
+                }
+            }
+        }
+
+        std::mem::swap(&mut prev, &mut cur);
+    }
+
+    // ── Resolve union-find: fold each region into its root ──
+    let n_labels = regions.len();
+    for lab in 0..n_labels {
+        let root = find(&mut regions, lab as u32) as usize;
+        if root != lab {
+            let (sw, swx, swy, np, pv, px, py) = {
+                let c = &regions[lab];
+                (
+                    c.sum_w, c.sum_wx, c.sum_wy, c.npix, c.peak_val, c.peak_x, c.peak_y,
+                )
+            };
+            let rt = &mut regions[root];
+            rt.sum_w += sw;
+            rt.sum_wx += swx;
+            rt.sum_wy += swy;
+            rt.npix += np;
+            if pv > rt.peak_val {
+                rt.peak_val = pv;
+                rt.peak_x = px;
+                rt.peak_y = py;
+            }
+        }
+    }
+
+    // ── Emit one centroid per root region ──
+    let cx = width as f32 / 2.0;
+    let cy = height as f32 / 2.0;
+    let mut centroids: Vec<Centroid> = Vec::new();
+    let mut num_blobs_raw = 0usize;
+    for lab in 0..n_labels {
+        if find(&mut regions, lab as u32) as usize != lab {
+            continue; // not a root
+        }
+        num_blobs_raw += 1;
+        let reg = regions[lab];
+        if (reg.npix as usize) < config.min_pixels || reg.sum_w <= 0.0 {
+            continue;
+        }
+        let mut fx = reg.sum_wx / reg.sum_w;
+        let mut fy = reg.sum_wy / reg.sum_w;
+
+        // Optional 3×3 parabola refine on the raw image at the peak, gated to
+        // agree with the CoM within 0.5 px (mirrors the CCL path).
+        let (pc, pr) = (reg.peak_x as usize, reg.peak_y as usize);
+        if reg.npix >= 5 && pc >= 1 && pr >= 1 && pc + 1 < w && pr + 1 < h {
+            let bg = bilinear_grid(&bg_grid, nx, ny, block, pc, pr) as f64;
+            let v = |dy: isize, dx: isize| -> f64 {
+                let rr = (pr as isize + dy) as usize;
+                let cc = (pc as isize + dx) as usize;
+                pixels[rr * w + cc] as f64 - bg
+            };
+            if let Some((x_off, y_off)) = quadratic_peak_offset(v) {
+                let (qx, qy) = (pc as f64 + x_off, pr as f64 + y_off);
+                if (qx - fx).powi(2) + (qy - fy).powi(2) < 0.25 {
+                    fx = qx;
+                    fy = qy;
+                }
+            }
+        }
+
+        centroids.push(Centroid {
+            x: fx as f32 - cx,
+            y: fy as f32 - cy,
+            mass: Some(reg.sum_w as f32),
+            cov: None,
+        });
+    }
+
+    centroids.sort_by(|a, b| {
+        b.mass
+            .unwrap_or(0.0)
+            .partial_cmp(&a.mass.unwrap_or(0.0))
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    if let Some(max) = config.max_centroids {
+        centroids.truncate(max);
+    }
+
+    let bg_mean = {
+        let mut g = bg_grid.clone();
+        let m = g.len() / 2;
+        let (_, nth, _) = g.select_nth_unstable_by(m, |a, b| a.partial_cmp(b).unwrap());
+        *nth
+    };
+
+    Ok(CentroidExtractionResult {
+        centroids,
+        image_width: width,
+        image_height: height,
+        background_mean: bg_mean,
+        background_sigma: sigma,
+        threshold: bg_mean + k * sigma,
+        num_blobs_raw,
+    })
+}
+
+/// Union-find root with path halving over the region accumulators.
+fn find(regions: &mut [Region], mut x: u32) -> u32 {
+    while regions[x as usize].parent != x {
+        let parent = regions[x as usize].parent;
+        regions[x as usize].parent = regions[parent as usize].parent; // halve
+        x = regions[x as usize].parent;
+    }
+    x
+}
+
+/// Link the roots of two region labels.
+fn union(regions: &mut [Region], a: u32, b: u32) {
+    let ra = find(regions, a);
+    let rb = find(regions, b);
+    if ra != rb {
+        regions[ra as usize].parent = rb;
+    }
+}
+
+/// Coarse background grid + global noise σ from a subsampled pre-pass.
+///
+/// The image is divided into `block × block` cells; each cell's median is taken
+/// from a strided subsample (~1/64 of the pixels for the default block), giving
+/// an `nx × ny` background grid. The global noise σ is the RMS of the
+/// below-median residuals across the subsample (the half-normal estimate,
+/// robust to stars which only push the distribution upward).
+///
+/// Returns `(grid, nx, ny, sigma)` with `grid` row-major `nx`-wide.
+fn coarse_background(
+    pixels: &[f32],
+    w: usize,
+    h: usize,
+    block: usize,
+) -> (Vec<f32>, usize, usize, f32) {
+    let nx = w.div_ceil(block);
+    let ny = h.div_ceil(block);
+    let stride = (block / 8).max(1);
+    let mut grid = vec![0.0_f32; nx * ny];
+    let mut sq_sum = 0.0_f64;
+    let mut sq_n = 0usize;
+    let mut samples: Vec<f32> = Vec::with_capacity((block / stride + 1).pow(2));
+
+    for by in 0..ny {
+        let y0 = by * block;
+        let y1 = (y0 + block).min(h);
+        for bx in 0..nx {
+            let x0 = bx * block;
+            let x1 = (x0 + block).min(w);
+            samples.clear();
+            let mut y = y0;
+            while y < y1 {
+                let row = y * w;
+                let mut x = x0;
+                while x < x1 {
+                    let v = pixels[row + x];
+                    if v.is_finite() {
+                        samples.push(v);
+                    }
+                    x += stride;
+                }
+                y += stride;
+            }
+            let median = if samples.is_empty() {
+                0.0
+            } else {
+                let m = samples.len() / 2;
+                let (_, nth, _) =
+                    samples.select_nth_unstable_by(m, |a, b| a.partial_cmp(b).unwrap());
+                *nth
+            };
+            grid[by * nx + bx] = median;
+            // Below-median residuals → robust noise (uncontaminated by stars).
+            for &v in samples.iter() {
+                if v <= median {
+                    let d = (v - median) as f64;
+                    sq_sum += d * d;
+                    sq_n += 1;
+                }
+            }
+        }
+    }
+
+    let sigma = if sq_n > 0 {
+        (sq_sum / sq_n as f64).sqrt() as f32
+    } else {
+        0.0
+    };
+    (grid, nx, ny, sigma)
+}
+
+/// Bilinear interpolation of a coarse background grid at pixel `(x, y)`.
+///
+/// Grid samples sit at block centers (`block/2 + bx·block`); positions outside
+/// the centers clamp to the nearest edge cell.
+fn bilinear_grid(grid: &[f32], nx: usize, ny: usize, block: usize, x: usize, y: usize) -> f32 {
+    let half = block as f32 / 2.0;
+    let fx = (x as f32 - half) / block as f32;
+    let fy = (y as f32 - half) / block as f32;
+    let bx0 = (fx.floor().max(0.0) as usize).min(nx - 1);
+    let by0 = (fy.floor().max(0.0) as usize).min(ny - 1);
+    let bx1 = (bx0 + 1).min(nx - 1);
+    let by1 = (by0 + 1).min(ny - 1);
+    let tx = (fx - bx0 as f32).clamp(0.0, 1.0);
+    let ty = (fy - by0 as f32).clamp(0.0, 1.0);
+    let g = |bx: usize, by: usize| grid[by * nx + bx];
+    let top = g(bx0, by0) * (1.0 - tx) + g(bx1, by0) * tx;
+    let bot = g(bx0, by1) * (1.0 - tx) + g(bx1, by1) * tx;
+    top * (1.0 - ty) + bot * ty
 }
 
 // ─── Internal helpers ──────────────────────────────────────────────────────
@@ -637,6 +1053,36 @@ fn estimate_background(
     (median, sigma)
 }
 
+/// Sub-pixel peak offset from a 2-D quadratic fit to a 3×3 neighborhood.
+///
+/// `v(dy, dx)` samples the (background-subtracted) surface at the peak pixel
+/// plus integer offset `(dy, dx)`, `dx`/`dy` ∈ {−1, 0, 1}. Fits a bivariate
+/// quadratic and returns the vertex offset `(x_off, y_off)` from the peak
+/// pixel, or `None` when the fit is degenerate (near-flat Hessian) or
+/// extrapolates beyond half a pixel (an unreliable peak — the caller should
+/// fall back to the integer peak / center-of-mass). Shared by the
+/// connected-component path ([`compute_blob_centroids`]) and the fast
+/// DoG path ([`extract_centroids_fast`]).
+fn quadratic_peak_offset(v: impl Fn(isize, isize) -> f64) -> Option<(f64, f64)> {
+    let b = (v(0, 1) - v(0, -1)) / 2.0;
+    let c_coeff = (v(1, 0) - v(-1, 0)) / 2.0;
+    let d = (v(0, 1) + v(0, -1) - 2.0 * v(0, 0)) / 2.0;
+    let f = (v(1, 0) + v(-1, 0) - 2.0 * v(0, 0)) / 2.0;
+    let e = (v(1, 1) - v(1, -1) - v(-1, 1) + v(-1, -1)) / 4.0;
+
+    let denom = 4.0 * d * f - e * e;
+    if denom.abs() <= 1e-10 {
+        return None;
+    }
+    let x_off = (e * c_coeff - 2.0 * f * b) / denom;
+    let y_off = (e * b - 2.0 * d * c_coeff) / denom;
+    if x_off.abs() <= 0.5 && y_off.abs() <= 0.5 {
+        Some((x_off, y_off))
+    } else {
+        None
+    }
+}
+
 /// Raw pixel-coordinate centroid with mass and covariance.
 struct RawCentroid {
     x_px: f32,
@@ -859,28 +1305,15 @@ fn compute_blob_centroids(
                     gray[r * w + c] as f64 - effective_bg
                 };
 
-                let b = (v(0, 1) - v(0, -1)) / 2.0;
-                let c_coeff = (v(1, 0) - v(-1, 0)) / 2.0;
-                let d = (v(0, 1) + v(0, -1) - 2.0 * v(0, 0)) / 2.0;
-                let f = (v(1, 0) + v(-1, 0) - 2.0 * v(0, 0)) / 2.0;
-                let e = (v(1, 1) - v(1, -1) - v(-1, 1) + v(-1, -1)) / 4.0;
-
-                let denom = 4.0 * d * f - e * e;
-                if denom.abs() > 1e-10 {
-                    let x_off = (e * c_coeff - 2.0 * f * b) / denom;
-                    let y_off = (e * b - 2.0 * d * c_coeff) / denom;
-
-                    // Only apply if offset is within half a pixel
-                    if x_off.abs() <= 0.5 && y_off.abs() <= 0.5 {
-                        let qx = pc as f64 + x_off;
-                        let qy = pr as f64 + y_off;
-                        // Only use quadratic when it agrees with CoM (within 0.5 px).
-                        // For asymmetric or blended blobs, CoM is more reliable.
-                        let dist_sq = (qx - xbar) * (qx - xbar) + (qy - ybar) * (qy - ybar);
-                        if dist_sq < 0.25 {
-                            final_x = qx;
-                            final_y = qy;
-                        }
+                if let Some((x_off, y_off)) = quadratic_peak_offset(v) {
+                    let qx = pc as f64 + x_off;
+                    let qy = pr as f64 + y_off;
+                    // Only use quadratic when it agrees with CoM (within 0.5 px).
+                    // For asymmetric or blended blobs, CoM is more reliable.
+                    let dist_sq = (qx - xbar) * (qx - xbar) + (qy - ybar) * (qy - ybar);
+                    if dist_sq < 0.25 {
+                        final_x = qx;
+                        final_y = qy;
                     }
                 }
             }
@@ -943,6 +1376,132 @@ mod tests {
         assert!(c.x.abs() < 1.0, "Expected x near 0, got {}", c.x);
         assert!(c.y.abs() < 1.0, "Expected y near 0, got {}", c.y);
         assert!(c.mass.unwrap() > 0.0);
+    }
+
+    /// Helper: render Gaussian stars on a background with an optional gradient
+    /// and deterministic (seedless) per-pixel noise of amplitude `noise`.
+    fn render_stars(
+        width: u32,
+        height: u32,
+        bg: f32,
+        gradient: f32,
+        noise: f32,
+        sigma_px: f32,
+        stars: &[(f32, f32, f32)],
+    ) -> Vec<f32> {
+        let (w, h) = (width as usize, height as usize);
+        let mut pixels = vec![0.0_f32; w * h];
+        for row in 0..h {
+            for col in 0..w {
+                // Large-scale gradient the coarse-grid background must reject,
+                // plus a cheap deterministic dither so the noise σ is nonzero.
+                let dither = (((row * w + col) as u32).wrapping_mul(2_654_435_761) >> 8) as f32
+                    / 16_777_216.0
+                    - 0.5;
+                pixels[row * w + col] = bg + gradient * (col as f32 / w as f32) + noise * dither;
+            }
+        }
+        for &(sx, sy, brightness) in stars {
+            for row in 0..h {
+                for col in 0..w {
+                    let dx = col as f32 - sx;
+                    let dy = row as f32 - sy;
+                    let r2 = dx * dx + dy * dy;
+                    pixels[row * w + col] += brightness * (-r2 / (2.0 * sigma_px * sigma_px)).exp();
+                }
+            }
+        }
+        pixels
+    }
+
+    #[test]
+    fn test_fast_extract_recovers_stars_over_gradient() {
+        let (width, height) = (128u32, 128u32);
+        let sigma_px = 1.6_f32;
+        // Sub-pixel true positions; a strong left-to-right gradient the
+        // coarse-grid background must track, plus realistic noise.
+        let stars = [
+            (30.3, 30.0, 900.0),
+            (90.0, 50.7, 1300.0),
+            (60.5, 100.2, 600.0),
+        ];
+        let pixels = render_stars(width, height, 50.0, 400.0, 8.0, sigma_px, &stars);
+
+        let config = FastCentroidConfig {
+            sigma_threshold: 5.0,
+            bg_grid: 32,
+            ..Default::default()
+        };
+        let result = extract_centroids_fast(&pixels, width, height, &config).unwrap();
+        assert_eq!(
+            result.centroids.len(),
+            3,
+            "expected 3 stars, got {}",
+            result.centroids.len()
+        );
+        // Brightest-first ordering.
+        assert!(result.centroids[0].mass.unwrap() >= result.centroids[1].mass.unwrap());
+
+        // Each true star must have a detection within ~0.6 px. The single-pass
+        // path is a ~0.5-px-class centroider by design (threshold-clipped CoM +
+        // parabola refine) — plenty for solving, not for tight astrometry.
+        let cx = width as f32 / 2.0;
+        let cy = height as f32 / 2.0;
+        for &(sx, sy, _) in &stars {
+            let (tx, ty) = (sx - cx, sy - cy);
+            let best = result
+                .centroids
+                .iter()
+                .map(|c| ((c.x - tx).powi(2) + (c.y - ty).powi(2)).sqrt())
+                .fold(f32::INFINITY, f32::min);
+            assert!(
+                best < 0.6,
+                "star ({sx}, {sy}) nearest detection {best:.3} px away"
+            );
+        }
+    }
+
+    #[test]
+    fn test_fast_extract_merges_touching_pixels_and_caps() {
+        let (width, height) = (128u32, 128u32);
+        // Two stars 1 px apart form one connected region (correct for a blended
+        // pair); a far star is its own region → 2 total.
+        let stars = [
+            (64.0, 64.0, 1000.0),
+            (65.0, 64.0, 950.0),
+            (20.0, 20.0, 800.0),
+        ];
+        let pixels = render_stars(width, height, 30.0, 0.0, 6.0, 1.5, &stars);
+
+        let config = FastCentroidConfig {
+            sigma_threshold: 5.0,
+            max_centroids: Some(5),
+            ..Default::default()
+        };
+        let result = extract_centroids_fast(&pixels, width, height, &config).unwrap();
+        assert_eq!(
+            result.centroids.len(),
+            2,
+            "blended pair should merge to 1 + 1 separate = 2, got {}",
+            result.centroids.len()
+        );
+    }
+
+    #[test]
+    fn test_fast_extract_rejects_bad_params() {
+        let pixels = vec![0.0_f32; 64 * 64];
+        let bad_sigma = FastCentroidConfig {
+            sigma_threshold: 0.0,
+            ..Default::default()
+        };
+        assert!(extract_centroids_fast(&pixels, 64, 64, &bad_sigma).is_err());
+        let bad_grid = FastCentroidConfig {
+            bg_grid: 0,
+            ..Default::default()
+        };
+        assert!(extract_centroids_fast(&pixels, 64, 64, &bad_grid).is_err());
+        // Length mismatch.
+        assert!(extract_centroids_fast(&pixels, 64, 63, &FastCentroidConfig::default()).is_err());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,8 +203,8 @@ pub use camera_model::CameraModel;
 pub use centroid::*;
 #[cfg(feature = "image")]
 pub use centroid_extraction::{
-    extract_centroids_from_image, extract_centroids_from_raw, CentroidExtractionConfig,
-    CentroidExtractionResult,
+    extract_centroids_fast, extract_centroids_from_image, extract_centroids_from_raw,
+    CentroidExtractionConfig, CentroidExtractionResult, FastCentroidConfig,
 };
 pub use distortion::{
     calibrate_camera, num_coeffs, CalibrateConfig, CalibrateResult, Distortion,

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -300,7 +300,35 @@ impl Default for GenerateDatabaseConfig {
 // ── Configuration for plate solving ─────────────────────────────────────────
 
 /// Parameters controlling the plate-solve attempt.
+///
+/// One config serves both solve modes. `solve_from_centroids` runs
+/// **lost-in-space** (pattern-hash search) unless an [`attitude_hint`] is set,
+/// in which case it runs **tracking** (direct correspondence from the hint)
+/// with automatic fallback to lost-in-space. The fields are grouped by which
+/// mode reads them — fields marked for one mode are ignored in the other:
+///
+/// - **Camera geometry** ([`camera_model`]) and **matching/verification**
+///   ([`match_radius`], [`match_threshold`], [`solve_timeout_ms`]) apply to
+///   both modes.
+/// - **Lost-in-space** ([`fov_max_error_rad`], [`match_max_error`]) tune the
+///   pattern search; ignored in tracking.
+/// - **Tracking** ([`attitude_hint`], [`hint_uncertainty_rad`],
+///   [`strict_hint`]) are inert unless `attitude_hint` is set.
+/// - **Stellar aberration** ([`observer_velocity_km_s`]) applies to both
+///   modes.
+///
+/// [`camera_model`]: SolveConfig::camera_model
+/// [`match_radius`]: SolveConfig::match_radius
+/// [`match_threshold`]: SolveConfig::match_threshold
+/// [`solve_timeout_ms`]: SolveConfig::solve_timeout_ms
+/// [`fov_max_error_rad`]: SolveConfig::fov_max_error_rad
+/// [`match_max_error`]: SolveConfig::match_max_error
+/// [`attitude_hint`]: SolveConfig::attitude_hint
+/// [`hint_uncertainty_rad`]: SolveConfig::hint_uncertainty_rad
+/// [`strict_hint`]: SolveConfig::strict_hint
+/// [`observer_velocity_km_s`]: SolveConfig::observer_velocity_km_s
 pub struct SolveConfig {
+    // ── Camera geometry (both modes) ──
     /// Camera intrinsics model — the single source of camera geometry.
     ///
     /// The model's focal length and image width define the solver's FOV
@@ -311,34 +339,32 @@ pub struct SolveConfig {
     /// FOV estimate is known, or pass a calibrated model from a previous
     /// solve / [`crate::calibrate_camera`] run.
     pub camera_model: CameraModel,
-    /// Maximum acceptable FOV error in radians. None = no FOV filtering.
-    ///
-    /// When set, the solver sweeps FOV values across
-    /// `fov_estimate ± fov_max_error` and rejects pattern matches implying a
-    /// FOV outside the range.
-    pub fov_max_error_rad: Option<f32>,
+
+    // ── Matching & verification (both modes) ──
     /// Maximum match distance as a fraction of the FOV. Default 0.01.
     pub match_radius: f32,
     /// False-positive probability threshold. Default 1e-5.
     pub match_threshold: f64,
     /// Timeout in milliseconds. None = no timeout. Default 5000.
     pub solve_timeout_ms: Option<u64>,
+
+    // ── Lost-in-space pattern search (ignored in tracking mode) ──
+    /// Maximum acceptable FOV error in radians. None = no FOV filtering.
+    ///
+    /// When set, the solver sweeps FOV values across
+    /// `fov_estimate ± fov_max_error` and rejects pattern matches implying a
+    /// FOV outside the range. *Lost-in-space only* — tracking takes its scale
+    /// from the hint and camera model.
+    pub fov_max_error_rad: Option<f32>,
     /// Maximum edge-ratio error for matching. None = use database value.
     ///
     /// Values below the database's `pattern_max_error` are clamped up to it —
     /// patterns were quantized at that tolerance during generation, so a
-    /// tighter match tolerance cannot be honored.
+    /// tighter match tolerance cannot be honored. *Lost-in-space only* —
+    /// tracking does not use the pattern hash.
     pub match_max_error: Option<f32>,
-    /// Observer's barycentric velocity in km/s (ICRS/GCRF Cartesian).
-    ///
-    /// When set, catalog star positions are aberration-corrected to apparent
-    /// positions before matching and refinement, removing the ~20" systematic
-    /// bias from Earth's orbital velocity.
-    ///
-    /// For ground-based or Earth-orbiting observers, this is dominated by
-    /// Earth's orbital velocity (~30 km/s). Default: `None` (no correction).
-    pub observer_velocity_km_s: Option<[f64; 3]>,
 
+    // ── Tracking (ignored unless `attitude_hint` is set) ──
     /// Optional attitude hint for tracking-mode solving.
     ///
     /// When set, the solver first attempts a fast direct-correspondence solve
@@ -355,7 +381,9 @@ pub struct SolveConfig {
     /// Tracking mode can succeed with as few as 3 matched stars (LIS needs 4)
     /// and is robust against pattern-hash failures from low-SNR or sparse
     /// fields. The main robustness assumption is that the hint is within
-    /// [`SolveConfig::hint_uncertainty_rad`] of the true attitude.
+    /// [`SolveConfig::hint_uncertainty_rad`] of the true attitude. Setting this
+    /// is what switches `solve_from_centroids` into tracking mode; `None`
+    /// (default) runs lost-in-space.
     pub attitude_hint: Option<Quaternion>,
 
     /// Angular uncertainty (radians) of [`SolveConfig::attitude_hint`].
@@ -374,6 +402,17 @@ pub struct SolveConfig {
     /// "fell back to LIS and succeeded with a different attitude than expected."
     /// Ignored unless `attitude_hint` is set. Default: `false`.
     pub strict_hint: bool,
+
+    // ── Stellar aberration (both modes) ──
+    /// Observer's barycentric velocity in km/s (ICRS/GCRF Cartesian).
+    ///
+    /// When set, catalog star positions are aberration-corrected to apparent
+    /// positions before matching and refinement, removing the ~20" systematic
+    /// bias from Earth's orbital velocity.
+    ///
+    /// For ground-based or Earth-orbiting observers, this is dominated by
+    /// Earth's orbital velocity (~30 km/s). Default: `None` (no correction).
+    pub observer_velocity_km_s: Option<[f64; 3]>,
 }
 
 impl Default for SolveConfig {

--- a/src/solver/wcs_refine.rs
+++ b/src/solver/wcs_refine.rs
@@ -122,30 +122,6 @@ pub fn cd_from_theta(theta: f64, pixel_scale: f64, parity_flip: bool) -> [[f64; 
     }
 }
 
-/// Decompose a CD matrix into rotation angle, pixel scale (x and y), and parity.
-///
-/// Returns `(theta_rad, scale_x, scale_y, parity_flip)`.
-#[cfg(test)]
-pub fn decompose_cd(cd: &[[f64; 2]; 2]) -> (f64, f64, f64, bool) {
-    let det = cd[0][0] * cd[1][1] - cd[0][1] * cd[1][0];
-    let parity_flip = det < 0.0;
-
-    // Scale = norm of each column
-    let scale_x = (cd[0][0] * cd[0][0] + cd[1][0] * cd[1][0]).sqrt();
-    let scale_y = (cd[0][1] * cd[0][1] + cd[1][1] * cd[1][1]).sqrt();
-
-    // Rotation angle from the first column (observed +X direction).
-    // For no parity: CD11 = ps*cos θ,  CD21 = ps*sin θ
-    // For parity:    CD11 = -ps*cos θ, CD21 = -ps*sin θ  (CD = ps·R(θ)·diag(−1,1))
-    let theta = if parity_flip {
-        (-cd[1][0]).atan2(-cd[0][0])
-    } else {
-        cd[1][0].atan2(cd[0][0])
-    };
-
-    (theta, scale_x, scale_y, parity_flip)
-}
-
 // ── 3×3 linear solve ────────────────────────────────────────────────────────
 
 /// Solve a 3×3 linear system `Ax = b` via Gaussian elimination with partial pivoting.
@@ -1198,16 +1174,21 @@ mod tests {
         let ps = 1.7e-5;
         let cd = cd_from_theta(theta, ps, false);
 
-        // det should be positive
+        // det positive (proper rotation), and CD == ps·R(θ) element-wise.
         let det = cd[0][0] * cd[1][1] - cd[0][1] * cd[1][0];
         assert!(det > 0.0);
-
-        // Decompose should recover theta and scale
-        let (t, sx, sy, parity) = decompose_cd(&cd);
-        assert!(!parity);
-        assert!((t - theta).abs() < 1e-12, "theta: {:.6} vs {:.6}", t, theta);
-        assert!((sx - ps).abs() < 1e-18, "scale_x: {:.6e} vs {:.6e}", sx, ps);
-        assert!((sy - ps).abs() < 1e-18, "scale_y: {:.6e} vs {:.6e}", sy, ps);
+        let (c, s) = (theta.cos(), theta.sin());
+        let expected = [[ps * c, -ps * s], [ps * s, ps * c]];
+        for i in 0..2 {
+            for j in 0..2 {
+                assert!(
+                    (cd[i][j] - expected[i][j]).abs() < 1e-18,
+                    "CD[{i}][{j}]: {:.6e} vs {:.6e}",
+                    cd[i][j],
+                    expected[i][j]
+                );
+            }
+        }
     }
 
     #[test]
@@ -1216,15 +1197,21 @@ mod tests {
         let ps = 2.0e-5;
         let cd = cd_from_theta(theta, ps, true);
 
-        // det should be negative
+        // det negative (mirror), and CD == ps·R(θ)·diag(−1, 1) element-wise.
         let det = cd[0][0] * cd[1][1] - cd[0][1] * cd[1][0];
         assert!(det < 0.0);
-
-        let (t, sx, sy, parity) = decompose_cd(&cd);
-        assert!(parity);
-        assert!((t - theta).abs() < 1e-12);
-        assert!((sx - ps).abs() < 1e-18);
-        assert!((sy - ps).abs() < 1e-18);
+        let (c, s) = (theta.cos(), theta.sin());
+        let expected = [[-ps * c, -ps * s], [-ps * s, ps * c]];
+        for i in 0..2 {
+            for j in 0..2 {
+                assert!(
+                    (cd[i][j] - expected[i][j]).abs() < 1e-18,
+                    "CD[{i}][{j}]: {:.6e} vs {:.6e}",
+                    cd[i][j],
+                    expected[i][j]
+                );
+            }
+        }
     }
 
     #[test]
@@ -1348,17 +1335,5 @@ mod tests {
             ang < 1e-6,
             "wcs_to_rotation disagrees with rotation_from_theta_crval by {ang:.2e} rad"
         );
-    }
-
-    #[test]
-    fn test_decompose_cd_identity_like() {
-        let ps = 1.5e-5;
-        // No rotation, no parity
-        let cd = [[ps, 0.0], [0.0, ps]];
-        let (theta, sx, sy, parity) = decompose_cd(&cd);
-        assert!(!parity);
-        assert!(theta.abs() < 1e-12);
-        assert!((sx - ps).abs() < 1e-18);
-        assert!((sy - ps).abs() < 1e-18);
     }
 }

--- a/tests/tess_solve_test.rs
+++ b/tests/tess_solve_test.rs
@@ -13,9 +13,10 @@ use numeris::Vector3;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
+use std::time::Instant;
 use tetra3::{
-    CalibrateConfig, CentroidExtractionConfig, DistortionModelType, GenerateDatabaseConfig,
-    SolveConfig, SolverDatabase,
+    extract_centroids_fast, CalibrateConfig, CentroidExtractionConfig, DistortionModelType,
+    FastCentroidConfig, GenerateDatabaseConfig, SolveConfig, SolverDatabase,
 };
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -543,6 +544,155 @@ fn test_tess_fits_solve() {
     );
     println!("══════════════════════════════════════════════════════════════");
     assert_eq!(failed, 0, "{} TESS solve tests failed", failed);
+}
+
+/// Benchmark: fast single-pass centroid path vs. the connected-component path
+/// on real TESS frames — speed, centroid-position agreement, end-to-end solve.
+///
+/// `#[ignore]` (timing/diagnostic, not a pass/fail gate). Run with:
+///   cargo test --test tess_solve_test --features image -- --ignored --nocapture bench_fast_vs_ccl
+/// Add `--features image,parallel` to time the multi-threaded blurs.
+#[test]
+#[ignore]
+fn bench_fast_vs_ccl_extraction() {
+    const REPS: u32 = 5;
+
+    for tc in TESS_TEST_CASES {
+        test_data::ensure_test_file(&format!("data/tess_test_images/{}", tc.filename));
+    }
+    let db = build_tess_database();
+
+    println!("\n══════════════════════════════════════════════════════════════");
+    println!("Fast single-pass vs. connected-component centroid extraction (best of {REPS})");
+    println!("══════════════════════════════════════════════════════════════");
+
+    for tc in TESS_TEST_CASES {
+        let fits_path = format!("data/tess_test_images/{}", tc.filename);
+        let hdus = read_fits_hdus(&fits_path);
+        let image_hdu = &hdus[1];
+        let naxis1 = match image_hdu.headers.get("NAXIS1") {
+            Some(FitsValue::Int(n)) => *n as u32,
+            _ => panic!("Missing NAXIS1"),
+        };
+        let naxis2 = match image_hdu.headers.get("NAXIS2") {
+            Some(FitsValue::Int(n)) => *n as u32,
+            _ => panic!("Missing NAXIS2"),
+        };
+        let pixels = read_f32_image(&fits_path, image_hdu);
+        let (trimmed, sci_width, sci_height) = trim_tess_science_region(&pixels, naxis1, naxis2);
+        let clean: Vec<f32> = trimmed
+            .iter()
+            .map(|&v| if v.is_finite() { v } else { 0.0 })
+            .collect();
+
+        let center_x = 44.0 + sci_width as f64 / 2.0;
+        let center_y = sci_height as f64 / 2.0;
+        let (b_ra, b_dec) = pixel_to_radec(image_hdu, center_x, center_y);
+        let true_boresight = radec_to_uvec(b_ra, b_dec);
+
+        let ccl_config = CentroidExtractionConfig {
+            sigma_threshold: 250.0,
+            min_pixels: 3,
+            max_pixels: 10000,
+            local_bg_block_size: Some(128),
+            max_elongation: Some(30.0),
+            ..Default::default()
+        };
+        // Single-pass detector: threshold in noise-σ above a coarse-grid
+        // background (independent of the ~250-DN raw threshold above).
+        let fast_config = FastCentroidConfig {
+            sigma_threshold: 8.0,
+            bg_grid: 128,
+            min_pixels: 3,
+            max_centroids: None,
+        };
+
+        let best = |f: &dyn Fn() -> usize| -> (f64, usize) {
+            let mut best_ms = f64::INFINITY;
+            let mut n = 0;
+            for _ in 0..REPS {
+                let t = Instant::now();
+                n = f();
+                best_ms = best_ms.min(t.elapsed().as_secs_f64() * 1e3);
+            }
+            (best_ms, n)
+        };
+
+        let ccl = tetra3::extract_centroids_from_raw(&clean, sci_width, sci_height, &ccl_config)
+            .expect("ccl extract");
+        let fast = extract_centroids_fast(&clean, sci_width, sci_height, &fast_config)
+            .expect("fast extract");
+
+        let (ccl_ms, _) = best(&|| {
+            tetra3::extract_centroids_from_raw(&clean, sci_width, sci_height, &ccl_config)
+                .unwrap()
+                .centroids
+                .len()
+        });
+        let (fast_ms, _) = best(&|| {
+            extract_centroids_fast(&clean, sci_width, sci_height, &fast_config)
+                .unwrap()
+                .centroids
+                .len()
+        });
+
+        // Cross-match: nearest CCL centroid to each fast centroid, ≤ 2 px.
+        let mut deltas: Vec<f32> = Vec::new();
+        for f in &fast.centroids {
+            let mut best_d = f32::INFINITY;
+            for c in &ccl.centroids {
+                let d = ((f.x - c.x).powi(2) + (f.y - c.y).powi(2)).sqrt();
+                best_d = best_d.min(d);
+            }
+            if best_d <= 2.0 {
+                deltas.push(best_d);
+            }
+        }
+        deltas.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let (median_d, max_d) = if deltas.is_empty() {
+            (f32::NAN, f32::NAN)
+        } else {
+            (deltas[deltas.len() / 2], *deltas.last().unwrap())
+        };
+
+        let solve_config = SolveConfig {
+            fov_max_error_rad: Some((2.0_f32).to_radians()),
+            match_radius: 0.005,
+            match_threshold: 1e-5,
+            solve_timeout_ms: Some(60_000),
+            match_max_error: None,
+            ..SolveConfig::new((12.0_f32).to_radians(), sci_width, sci_height)
+        };
+        let boresight_err_arcmin = |cents: &[tetra3::Centroid]| -> Option<f32> {
+            let sol = db.solve_from_centroids(cents, &solve_config).ok()?;
+            let bs = sol.qicrs2cam.inverse() * Vector3::from_array([0.0, 0.0, 1.0]);
+            Some(angular_separation(&bs, &true_boresight).to_degrees() * 60.0)
+        };
+        let ccl_err = boresight_err_arcmin(&ccl.centroids);
+        let fast_err = boresight_err_arcmin(&fast.centroids);
+
+        println!("\n{} ({}×{})", tc.filename, sci_width, sci_height);
+        println!(
+            "  CCL : {:6.1} ms   {:4} centroids   solve {}",
+            ccl_ms,
+            ccl.centroids.len(),
+            ccl_err.map_or("FAIL".into(), |e| format!("{e:.2}' err")),
+        );
+        println!(
+            "  Fast: {:6.1} ms   {:4} centroids   solve {}",
+            fast_ms,
+            fast.centroids.len(),
+            fast_err.map_or("FAIL".into(), |e| format!("{e:.2}' err")),
+        );
+        println!(
+            "  speedup {:.2}×   |   {} matched ≤2px: median Δ {:.3} px, max {:.3} px",
+            ccl_ms / fast_ms,
+            deltas.len(),
+            median_d,
+            max_d,
+        );
+    }
+    println!("══════════════════════════════════════════════════════════════");
 }
 
 /// Test the polynomial distortion fitting pipeline on TESS images.

--- a/tests/tess_solve_test.rs
+++ b/tests/tess_solve_test.rs
@@ -402,8 +402,12 @@ fn test_tess_fits_solve() {
         // Compute true boresight from the WCS at the center of the science region.
         // The science region starts at column 44 in the full frame, so the center
         // pixel in full-frame coordinates is (44 + sci_width/2, sci_height/2).
-        let center_x = 44.0 + sci_width as f64 / 2.0;
-        let center_y = sci_height as f64 / 2.0;
+        // Geometric center of the trimmed science region in full-frame
+        // 0-indexed coords: region spans columns [44, 44+sci_width-1], rows
+        // [0, sci_height-1], so the center is (W-1)/2 — matching tetra3rs's
+        // centroid origin (issue #28).
+        let center_x = 44.0 + (sci_width - 1) as f64 / 2.0;
+        let center_y = (sci_height - 1) as f64 / 2.0;
         let (boresight_ra, boresight_dec) = pixel_to_radec(image_hdu, center_x, center_y);
         let true_boresight = radec_to_uvec(boresight_ra, boresight_dec);
 
@@ -585,8 +589,12 @@ fn bench_fast_vs_ccl_extraction() {
             .map(|&v| if v.is_finite() { v } else { 0.0 })
             .collect();
 
-        let center_x = 44.0 + sci_width as f64 / 2.0;
-        let center_y = sci_height as f64 / 2.0;
+        // Geometric center of the trimmed science region in full-frame
+        // 0-indexed coords: region spans columns [44, 44+sci_width-1], rows
+        // [0, sci_height-1], so the center is (W-1)/2 — matching tetra3rs's
+        // centroid origin (issue #28).
+        let center_x = 44.0 + (sci_width - 1) as f64 / 2.0;
+        let center_y = (sci_height - 1) as f64 / 2.0;
         let (b_ra, b_dec) = pixel_to_radec(image_hdu, center_x, center_y);
         let true_boresight = radec_to_uvec(b_ra, b_dec);
 
@@ -845,8 +853,8 @@ fn test_tess_distortion_fit_and_center_accuracy() {
         let (solved_ra, solved_dec) = solution_dist.pixel_to_world(0.0, 0.0);
 
         // Center of science region in full-frame 0-indexed coordinates
-        let center_x_ff = 44.0 + sci_width as f64 / 2.0;
-        let center_y_ff = sci_height as f64 / 2.0;
+        let center_x_ff = 44.0 + (sci_width - 1) as f64 / 2.0;
+        let center_y_ff = (sci_height - 1) as f64 / 2.0;
         let (wcs_ra, wcs_dec) = pixel_to_radec(image_hdu, center_x_ff, center_y_ff);
 
         let sep_arcmin = angular_separation(
@@ -1177,8 +1185,8 @@ fn test_tess_multi_image_calibration() {
 
         let (solved_ra, solved_dec) = solution.pixel_to_world(0.0, 0.0);
 
-        let center_x_ff = 44.0 + img.sci_width as f64 / 2.0;
-        let center_y_ff = img.sci_height as f64 / 2.0;
+        let center_x_ff = 44.0 + (img.sci_width - 1) as f64 / 2.0;
+        let center_y_ff = (img.sci_height - 1) as f64 / 2.0;
         let (wcs_ra, wcs_dec) = pixel_to_radec(&hdu_for_wcs, center_x_ff, center_y_ff);
 
         let sep_arcsec = angular_separation(


### PR DESCRIPTION
Bundles the 0.8.0 release prep with two centroid-related changes. Held as a **draft** until ready to tag.

Closes #28.

## 1. Release prep (`chore(release): prepare 0.8.0`)
- Bumps all three version files in lockstep — `Cargo.toml`, `pyproject.toml`, `python/Cargo.toml` — `0.7.4 → 0.8.0`, plus regenerated `Cargo.lock`.
- Converts the CHANGELOG `Unreleased` section to a tagged **0.8.0** release with a consolidated note that 0.7.x binary databases and pickles won't load (`SolveResult → Result`, new `RadialDistortion::center` field).
- README: removes the two 0.7.0-specific admonition blocks, refreshes the distortion feature bullet (full Brown-Conrady + free optical center) and the pickle-types note (`SolveFailure`); **status stays Alpha**.

> ⚠️ Tag-ready: pushing `v0.8.0` after merge triggers `publish.yml` → PyPI wheels (the 20-job matrix from #39). crates.io is still a manual `cargo publish -p tetra3`.

## 2. Fast single-pass centroider (`feat(centroid): fast single-pass star-tracker extractor`)
New `extract_centroids_fast` / `FastCentroidConfig` (Rust + Python) — an "adequate star tracker" path alongside the connected-component extractor (which stays the default).

- **Algorithm:** read each pixel once — subsampled coarse-background pre-pass, then a single raster sweep that thresholds against the interpolated background and groups lit pixels via run-length + union-find with inline intensity-weighted moments; one CoM per region (3×3 parabola refine, gated to the CoM). No convolution, no second pass.
- **Speed/accuracy (2048² TESS, single-threaded):** ~26–32 ms vs ~126 ms = **~4–5×**; equal solve error; ~0.1 px centroid agreement on bright stars.
- Drop-in: returns the same `ExtractionResult`. Trades faint-star sensitivity / sub-pixel accuracy for speed — use `extract_centroids` for calibration.

## 3. Geometric-center origin fix (`fix(centroid)!: move origin to geometric center (W-1)/2`) — issue #28
- Centroid/pixel origin moved from `W/2, H/2` to **`(W−1)/2, (H−1)/2`** (pixel centers at integer indices → 4-pixel intersection for even dims, middle pixel for odd), matching FITS / astropy / astrometry.net / OpenCV.
- Removes a ~½-pixel (~130–250″ wide-field) bias when comparing against those tools or using a `crpix` derived from one. Old origin was internally consistent, so tetra3rs-only solves were unbiased; returned centroids/boresight now shift ½ px toward the geometric center.
- **Breaking:** caller-supplied centroids should now use the `(W−1)/2` origin. TESS test truth centers updated to match.
- **Docs:** `coordinates.md` rewritten — precise origin definition, "center vs corner" note, and an explicit statement that the solved attitude points at the **center pixel**, not the optical/distortion axis; `crpix` "optical center" mislabels fixed in `camera-model.md`/`wcs.md`; new concept section + API-reference entry for `extract_centroids_fast`.

## Tests
- Rust: 63 lib unit tests pass; TESS integration solve 3/3 (boresight unchanged — origin + truth-center moved together). `#[ignore]` real-image benchmark in `tess_solve_test.rs`.
- Python: 38 `test_basic.py` tests pass (incl. fast-path tests + functions-exist check); type stubs updated.
- `cargo clippy --all-targets --all-features -D warnings` and `cargo fmt --all --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Changelog detail (moved from CHANGELOG.md on 2026-08-29)

The release-notes text for 0.8.0 that shipped in `CHANGELOG.md` before it was condensed to one-liners. Preserved here verbatim so the PR is the record of detail.


> **Note on serialized artifacts.** 0.8.0 changes the on-the-wire format of
> several public types, so binary databases and pickles saved by 0.7.x do not
> load: `SolveResult` (now `Result<Solution, SolveFailure>`) and any
> `RadialDistortion` / `CameraModel` (new `RadialDistortion::center` field).
> Regenerate databases and re-pickle results after upgrading.

### Added

- **Fast single-pass centroid extractor — an "adequate star tracker" path.**
  `extract_centroids_fast` (Rust + Python) / `FastCentroidConfig` reads each
  pixel once: a cheap subsampled pre-pass builds a coarse background grid, then
  a single raster sweep thresholds against the interpolated background and
  groups lit pixels into connected regions via run-length + union-find,
  accumulating intensity-weighted moments inline and emitting one center-of-mass
  per region (with an optional 3×3 parabola peak refine). No convolution and no
  second pass, so it is memory-bandwidth-bound: **~4–5× faster** than the
  connected-component path single-threaded on 2048² TESS frames (~26–32 ms vs
  ~126 ms), with equal solve accuracy and ~0.1 px centroid agreement on bright
  stars. It trades faint-star sensitivity and tight sub-pixel accuracy for
  speed; `extract_centroids` / `extract_centroids_from_raw` stay the default and
  the right choice for calibration and faint-star work. Returns the same
  `ExtractionResult`, so it is a drop-in for `solve_from_centroids`.

### Changed

- **Centroid origin moved to the geometric image center `(W−1)/2`, `(H−1)/2`
  (was `W/2`, `H/2`).** Pixel centers sit at integer indices, so the geometric
  center — the intersection of the four central pixels for even dimensions, the
  middle pixel for odd — is at `(W−1)/2`, a half-pixel left of and above the old
  origin. This matches the FITS / astropy / astrometry.net / OpenCV convention,
  removing a ~½-pixel (~130–250″ on a wide-field camera) bias when comparing
  tetra3rs solutions against those tools or feeding them a `crpix` derived from
  one. The old origin was internally consistent, so tetra3rs-only solves were
  not biased; returned centroid coordinates and the boresight now shift by half
  a pixel toward the geometric center. Applies to `extract_centroids`,
  `extract_centroids_fast`, and any caller-supplied centroids (which should now
  use the `(W−1)/2` origin). The docs' coordinate page now also states
  explicitly that the solved attitude is the direction at the **center pixel**,
  not the optical/distortion axis. (Issue #28.)

- **Radial calibration rewritten as a standard camera-intrinsics fit
  (OpenCV-style).** `calibrate_camera(model = Radial)` now jointly fits the
  optical-axis position `(cx, cy)`, a focal-scale factor `γ`, and the
  Brown-Conrady coefficients `(k1, k2, k3, p1, p2)` — the same parameter
  set as OpenCV's `calibrateCamera` (free principal point, free focal
  length). Two structural problems in the old fit are gone:
  - *No scale degree of freedom.* The fit was anchored to the focal length
    implied by the median solve FOV — a whole-field average biased by the
    very distortion being fit (≈0.8% on TESS, ~12 px at the field corner).
    Brown-Conrady has no linear term, so the bias had to be mimicked by the
    cubic+ terms, making results hypersensitive to the FOV estimate. The
    fitted `γ` now absorbs it exactly and is folded into
    `CameraModel::focal_length_px` (with the exact coefficient rescaling
    `kᵢ → kᵢ/γ^2i`, `p → p/γ`).
  - *Optical center pinned to the image center.* The old `(cx, cy)`
    regularizer pulled the distortion center to `[0, 0]`, which is wrong on
    mosaic cameras (TESS, Kepler, Rubin, …) where the optical axis lies far
    off any single detector — near a CCD corner for TESS Camera 1 CCD 1.
    The center is now free, with only a tiny tie-breaking prior for the
    weak-distortion case where it is genuinely unidentifiable.

  The fitter also normalizes coordinates internally (the Jacobian otherwise
  spans ~20 orders of magnitude and LM fails at real-camera scales) and no
  longer discards the fit when the LM iteration budget is reached. On the
  TESS 10-image radial calibration this takes the pooled fit from 6.3 px
  (or 3.0 px with 60% of points clipped, depending on the FOV estimate) to
  1.8 px with 80% inliers, and post-calibration re-solves agree with the
  FITS WCS to better than 90″ on all sectors.

- **`RadialDistortion` carries its own distortion center.** New
  `center: [f64; 2]` field (pixels, image-center-origin frame; default
  `[0, 0]`) and `with_center()` constructor. The distortion center (optical
  axis) is now distinct from `CameraModel::crpix` (the tangent-plane
  projection origin): radial calibrations leave `crpix = [0, 0]` and store
  the fitted optical-axis position in the model, so solve-time geometry
  (FOV-radius catalog queries, pattern scales) is unaffected even when the
  optical axis sits 1400 px off the image center. **Breaking:** saved
  binary/pickled `RadialDistortion` (and containing `CameraModel`) blobs
  from earlier versions do not load. Python: `RadialDistortion` gains a
  `center=(cx, cy)` constructor argument and property.

- **Calibrated `focal_length_px` is now tan-consistent.** Both calibrate
  paths previously recorded `focal_length_px = image_width / fov_rad`
  (small-angle) while fitting distortion against tan-projected ideal points
  (`f = (w/2)/tan(fov/2)`), a ~0.3% inconsistency at TESS's 11.7° FOV. Both
  now use the tan form, matching `CameraModel::from_fov` / `fov_rad()`.

- **Multi-image calibration excludes parity-outlier solves.** Parity is a
  physical property of the camera, so all images in a calibration set must
  agree; a lone opposite-parity solve is a false (mirror-image) match whose
  star correspondences would poison the pooled distortion fit. Images
  disagreeing with the majority parity are now excluded (debug-logged), and
  the median-FOV/parity consensus is computed over agreeing solves only.
  (Seen on TESS sector 14, which falsely solves as a mirror image with 427
  "matches" at rmse 275″.)

### Fixed

- **Parity-flipped solves no longer return a corrupt attitude.** For images
  requiring a parity flip (`parity_flip = true`), the final rotation was
  rebuilt from `(θ, CRVAL)` with a parity branch that produced a *reflection*
  (det −1) instead of a rotation. `Quaternion::from_rotation_matrix` cannot
  represent a reflection, so `qicrs2cam` was meaningless (a non-unit,
  near-identity quaternion), and the recomputed residual statistics
  (`rmse_rad`, `p90e_rad`, `max_err_rad`) were degrees-level garbage. The
  exported `cd_matrix` encoded the roll with the wrong sign convention
  (`ps·diag(−1,1)·R(θ)` instead of `ps·R(θ)·diag(−1,1)`). The bug was
  invisible to the test suite because no test exercised an end-to-end
  parity-flipped solve (the skyview tests pre-correct parity and the
  synthetic fields are proper). Now: the rotation/quaternion always describe
  the x-negated (proper) working frame — `Solution.parity_flip` records the
  mirror, exactly as documented — `cd_from_theta` emits the matching CD
  convention, and `wcs_to_rotation` returns the proper working-frame rotation
  for `det(CD) < 0` inputs. `Solution::pixel_to_world` / `world_to_pixel`
  were already consistent and are unchanged. Covered by new unit tests and an
  end-to-end mirrored-field integration test (`test_parity_flipped_solve`).
  Rust API note: `rotation_from_theta_crval` no longer takes a `parity_flip`
  argument (the rotation does not depend on it).

### Breaking changes

- **Python: `solve_from_centroids` returns a `SolveFailure` object instead of
  `None` on failure.** The new object is *falsy* — `if result:` keeps working
  — and carries `status` (`'no_match'` / `'timeout'` / `'too_few'`) and
  `solve_time_ms`, which were previously discarded. Code using
  `result is None` / `result is not None` must switch to truthiness checks
  (`if not result:` / `if result:`). `SolveFailure` pickles like the other
  public types.

- **`SolveResult` is now `Result<Solution, SolveFailure>` (Rust).** The old
  struct-of-`Option`s is replaced by a `Solution` whose fields are all
  guaranteed present (`qicrs2cam: Quaternion`, `fov_rad: f32`, `camera_model:
  CameraModel`, `cd_matrix`, `crval_rad`, `theta_rad`, …) and a `SolveFailure
  { status, solve_time_ms }` for the `NoMatch` / `Timeout` / `TooFew`
  outcomes (`SolveStatus::MatchFound` is gone — success is the `Ok` arm).
  `Solution::pixel_to_world` is now infallible and the legacy CD-matrix and
  quaternion+FOV fallback transform paths are deleted (every `Solution`
  carries a camera model and θ). `calibrate_camera` and the distortion
  fitters still accept failed solves in their input slices and skip them.
  **Python:** `solve_from_centroids` still returns a `SolveResult` object or
  `None`; the change is that its attributes (`fov_deg`, `num_matches`,
  `rmse_arcsec`, `camera_model`, `cd_matrix`, …) are no longer `Optional`,
  and scalar `pixel_to_world` always returns a tuple. Pickles of
  `SolveResult` objects from earlier versions do not load (wire format
  changed).

- **`SolveConfig`: `CameraModel` is now the single source of camera geometry
  (Rust).** The redundant `fov_estimate_rad`, `image_width`, and
  `image_height` fields are removed; the FOV estimate, image dimensions, and
  pixel scale all derive from `camera_model` (new accessors
  `fov_estimate_rad()`, `image_width()`, `image_height()`, and a
  `SolveConfig::with_camera_model()` constructor). `SolveConfig::new(fov, w,
  h)` is unchanged and remains the easy path. This removes the possibility of
  an inconsistent config (e.g. a calibrated model alongside a mismatched FOV
  estimate — previously the estimate silently won) and deletes the tracking
  path's "is the camera model real?" heuristic. The **Python API is
  unchanged** except for precedence: when `camera_model=` is passed, its focal
  length and dimensions are now authoritative and `fov_estimate_*` /
  `image_shape` are ignored (previously `fov_estimate` set the pixel scale
  even alongside a model).
- **Removed `SolveConfig::refine_iterations` (Rust) and the
  `refine_iterations=` kwarg of `solve_from_centroids` (Python).** The field
  was never read by the solver — the documented "number of iterative SVD
  refinement passes" did not exist; refinement depth has always been governed
  by the WCS refinement loop's internal convergence (stable match set, capped
  at 10 outer iterations). Setting it had no effect, so removal does not
  change solver behavior. Python callers passing `refine_iterations=` must
  drop the argument.

### Solver robustness

- **No more panics on degenerate input.** A failed SVD during attitude
  estimation (e.g. pathological/duplicate centroids) now skips the candidate
  (lost-in-space) or fails the hinted solve (tracking) instead of panicking;
  NaN residuals no longer panic the WCS refinement's median/MAD statistics;
  an empty pattern catalog (corrupt database) returns `NoMatch` instead of
  dividing by zero.
- **FOV sweep no longer aborts early on cluster-buster `TooFew`.** The
  post-thinning "too few pattern centroids" condition depends on the FOV being
  tried; the sweep now continues to other FOV values instead of returning.
  A genuine input of fewer than 4 centroids still returns `TooFew` immediately.
- **Verification cone sized for portrait images.** The catalog query radius
  now uses the true image diagonal (`sqrt(1 + (h/w)²)`, floored at the
  historical 1.42 factor) instead of assuming a square/landscape sensor.
- **Tracking solves are now aberration-consistent.** With
  `observer_velocity_km_s` set, the hinted-solve path previously matched
  against aberration-corrected star positions but ran the WCS refinement and
  residual statistics against the raw catalog vectors. Tracking now uses the
  same corrected unit-vector slice as lost-in-space end to end.

### Internal

- Deduplicated solver helpers: one `separation_for_density` (was copied in
  `solve.rs` and `database.rs`), one generic pattern centroid-distance sort,
  shared `focal_length_from_fov` / `pixel_scale_from_fov` for the pinhole
  formula, and extracted `compute_residuals` / `ls_fit_once` in the WCS
  refinement (the residual loop appeared three times, the LS pass twice).
  Brightness sorting is hoisted out of the per-FOV loop; the tracking solver's
  catalog-index reverse lookup is gone (match pairs now carry local indices).
- One verification and one refinement pipeline: the catalog-projection /
  greedy-match / binomial-FPR verification block and the WCS-refine +
  finalize tail are now single shared methods (`verify_attitude`,
  `refine_and_finalize`) used by both the lost-in-space and tracking paths
  (each previously had its own copy). The final attitude is derived directly
  from the constrained-fit parameters (θ, CRVAL, parity) and the locked pixel
  scale instead of synthesizing a CD matrix and decomposing it back into a
  rotation and FOV.

