### PR TITLE
Verification statistics recalibration (honest acceptance test)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 ## Unreleased
 
+### Changed — verification statistics recalibrated (solve-acceptance semantics)
+
+The lost-in-space acceptance test was rebuilt around honest statistics; no
+public API changed, but what the solver accepts (and how fast it fails) did:
+
+- **Null model measured, not assumed.** The false-positive probability of a
+  match count now uses the *measured* density of projected catalog stars over
+  the frame with the correct π·r² disc area. The previous `num_nearby·mr²`
+  under-predicted coincidence rates 2-3× per match — compounding to a latent
+  false-accept vulnerability in dense fields (a wrong-attitude TESS candidate
+  matching 113 stars by pure coincidence scored as a 10⁻¹⁴ certainty; it is
+  now correctly rejected at p≈1).
+- **Hypothesis stars aren't evidence.** The 4 pattern stars that formed the
+  candidate are excluded from the binomial trials and successes (upstream
+  tetra3's flat "−2" heuristic dropped). Tracking verification, whose hint is
+  independent of the centroids, no longer takes any discount.
+- **Sequential multiple-comparison correction.** Candidate `k` is accepted at
+  `p·k < match_threshold` — a Bonferroni correction over candidates *actually
+  tested* rather than the old division by the database pattern count, which
+  over-corrected by 4-7 orders of magnitude and made clean sparse fields
+  (< ~7 stars) mathematically unsolvable at any signal quality.
+  `match_threshold` is now a per-solve false-accept budget (the total for a
+  full search is bounded by a small logarithmic multiple);
+  `Solution.prob` reports the corrected p-value.
+- **Post-refinement re-verification.** Acceptance is decided by re-verifying
+  the *refined* attitude at a radius tied to the refined RMSE. A true
+  candidate's matches sit within a few RMSE (its p-value collapses by tens of
+  orders when the radius tightens); a false candidate's coincidences are
+  uniform across the search radius and cannot be aligned by the 3-DOF fit.
+- **Robust to wrong FOV estimates at full speed.** Candidate vectors are
+  rebuilt at the FOV measured from each matched pattern, so the FOV sweep
+  collapses to a pattern-tolerance-derived step (usually a single value):
+  a 15%-wrong FOV estimate now solves in ~36 µs instead of ~21-40 ms, and
+  unsolvable fields fail in ~1.6 ms instead of ~12-29 ms (10° defaults).
+
+Measured consequences (synthetic 10° harness, 1000 fields each): 6-star
+fields 71% solvable and 8-star fields 92% (both 0% before by construction),
+zero wrong-attitude accepts across 1500 pure-noise fields and all solved
+scenarios. Real-sky solves that previously passed only by the old
+arithmetic's optimism — e.g. heavily distorted TESS frames solved with an
+uncalibrated camera model at tight `match_radius`, where the true-match rate
+barely exceeds chance — may now fail or time out; raise `match_threshold`
+(e.g. `1e-3`) to accept such weak evidence explicitly, or calibrate the
+distortion first (the tiered calibration flow does this automatically).
+
 > **Note on serialized artifacts.** The `Solution` wire format changed (the
 > write-only `image_width`/`image_height` fields were removed — the same values
 > live in `Solution.camera_model`), so Python `SolveResult` pickles saved by

--- a/examples/profile_solve.rs
+++ b/examples/profile_solve.rs
@@ -154,14 +154,20 @@ fn main() {
     //   T3_RANDOM=1    each field is ENTIRELY random centroids (forces no-match:
     //                  full combination enumeration × full FOV sweep)
     //   T3_FOV_BIAS=x  bias the solver's FOV estimate by fraction x (see below)
+    //   T3_MAX_CENTROIDS=N  keep only the N brightest true centroids per field
+    //                  (sparse-field scenario; fields with fewer than 4 are
+    //                  regenerated as usual)
     let spurious: usize = std::env::var("T3_SPURIOUS")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(0);
     let random_only = std::env::var("T3_RANDOM").is_ok();
+    let max_centroids: Option<usize> = std::env::var("T3_MAX_CENTROIDS")
+        .ok()
+        .and_then(|s| s.parse().ok());
     let half_w_px = half_fov / pixel_scale; // image half-extent in pixels
     eprintln!(
-        "Scenario: random_only={random_only}, spurious_per_field={spurious}, fov_bias={fov_bias}"
+        "Scenario: random_only={random_only}, spurious_per_field={spurious}, fov_bias={fov_bias}, max_centroids={max_centroids:?}"
     );
 
     let mut rng = Rng(0x9E37_79B9_7F4A_7C15);
@@ -176,8 +182,12 @@ fn main() {
         }
     };
 
-    // Pre-generate centroid sets so RNG / projection work is outside the timed loop.
+    // Pre-generate centroid sets so RNG / projection work is outside the timed
+    // loop. `truths` holds each field's true boresight so solutions can be
+    // checked for correctness (a wrong-attitude accept must count as a false
+    // positive, not a solve).
     let mut sets: Vec<Vec<Centroid>> = Vec::with_capacity(n_trials as usize);
+    let mut truths: Vec<Vector3<f32>> = Vec::with_capacity(n_trials as usize);
     while (sets.len() as u32) < n_trials {
         let ra = rng.unit() * 2.0 * std::f32::consts::PI;
         let dec = (rng.unit() * 2.0 - 1.0).asin();
@@ -190,6 +200,15 @@ fn main() {
         } else {
             generate_centroids(&db, &rot, &boresight, half_fov, pixel_scale)
         };
+        if let Some(n) = max_centroids {
+            c.sort_by(|a, b| {
+                b.mass
+                    .unwrap_or(f32::MIN)
+                    .partial_cmp(&a.mass.unwrap_or(f32::MIN))
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+            c.truncate(n);
+        }
         if random_only {
             add_spurious(&mut c, &mut rng, spurious.max(30));
         } else {
@@ -197,6 +216,7 @@ fn main() {
         }
         if c.len() >= 4 {
             sets.push(c);
+            truths.push(boresight);
         }
     }
 
@@ -209,23 +229,35 @@ fn main() {
     tetra3::solver::profiling::reset();
 
     let mut n_found = 0u32;
+    let mut n_wrong = 0u32;
     let mut total_solve_ns: u128 = 0;
     let t_all = Instant::now();
-    for c in &sets {
+    for (c, truth) in sets.iter().zip(&truths) {
         let t = Instant::now();
         let r = db.solve_from_centroids(c, &solve_config);
         total_solve_ns += t.elapsed().as_nanos();
-        if r.is_ok() {
+        if let Ok(sol) = r {
             n_found += 1;
+            // Check the solved boresight against truth: an accepted wrong
+            // attitude (> 1° off) is a false positive, not a solve. For
+            // T3_RANDOM fields the stored truth is meaningless, but any
+            // accept there is a false positive by construction anyway.
+            let q = sol.qicrs2cam;
+            let bs = q.to_rotation_matrix().transpose() * Vector3::from_array([0.0, 0.0, 1.0]);
+            let dot = (bs[0] * truth[0] + bs[1] * truth[1] + bs[2] * truth[2]).clamp(-1.0, 1.0);
+            if dot.acos() > 1.0_f32.to_radians() {
+                n_wrong += 1;
+            }
         }
     }
     let wall = t_all.elapsed();
 
     println!("\n═══════════════════════════════════════════════════════════════");
     println!(
-        "Profiled {} solves ({} found), wall {:.3}s",
+        "Profiled {} solves ({} found, {} WRONG-ATTITUDE), wall {:.3}s",
         sets.len(),
         n_found,
+        n_wrong,
         wall.as_secs_f64()
     );
     println!(

--- a/python/src/solver_database.rs
+++ b/python/src/solver_database.rs
@@ -149,7 +149,11 @@ impl PySolverDatabase {
     ///         Can be used instead of image_width/image_height.
     ///     fov_max_error: Maximum FOV error in degrees. None = no filtering.
     ///     match_radius: Match distance as fraction of FOV. Default 0.01.
-    ///     match_threshold: False-positive probability threshold. Default 1e-5.
+    ///     match_threshold: False-positive probability budget for accepting a
+    ///         solution (candidate p-values are tested against this with a
+    ///         sequential multiple-comparison correction). Raising it (e.g. 1e-3)
+    ///         accepts weaker evidence — useful for very sparse fields at
+    ///         increased false-positive risk. Default 1e-5.
     ///     solve_timeout_ms: Timeout in milliseconds. None = no timeout.
     ///     match_max_error: Maximum edge-ratio error. None = use database value.
     ///         Values below the database's pattern quantization error are clamped up to it.

--- a/python/tetra3rs/__init__.pyi
+++ b/python/tetra3rs/__init__.pyi
@@ -685,7 +685,11 @@ class SolverDatabase:
                 At most one of fov_max_error_deg or fov_max_error_rad can be provided.
                 Lost-in-space only — tracking takes its scale from the hint.
             match_radius: Match distance as fraction of FOV.
-            match_threshold: False-positive probability threshold.
+            match_threshold: False-positive probability budget for accepting
+                a solution (candidate p-values are tested against this with a
+                sequential multiple-comparison correction). Raising it (e.g.
+                1e-3) accepts weaker evidence — useful for very sparse fields
+                at increased false-positive risk.
             solve_timeout_ms: Timeout in milliseconds. None = no timeout.
             match_max_error: Maximum edge-ratio error. None = use database value.
                 Values below the database's pattern quantization error are clamped up to it.

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -395,7 +395,18 @@ pub struct SolveConfig {
     // ── Matching & verification (both modes) ──
     /// Maximum match distance as a fraction of the FOV. Default 0.01.
     pub match_radius: f32,
-    /// False-positive probability threshold. Default 1e-5.
+    /// False-positive probability budget for accepting a solution.
+    /// Default 1e-5.
+    ///
+    /// Each candidate attitude's verification yields a binomial p-value (the
+    /// probability that a wrong attitude would coincidentally match as many
+    /// stars); candidate `k` of a lost-in-space search is accepted when
+    /// `p·k < match_threshold` — a sequential Bonferroni correction over the
+    /// candidates actually tested, so the total false-accept probability of a
+    /// full search stays within a small (logarithmic) multiple of this
+    /// budget. Tracking tests a single hinted candidate against the budget
+    /// directly. Raising this (e.g. `1e-3`) accepts weaker evidence — useful
+    /// for very sparse fields (≲7 stars) at increased false-positive risk.
     pub match_threshold: f64,
     /// Timeout in milliseconds. None = no timeout. Default 5000.
     pub solve_timeout_ms: Option<u64>,
@@ -566,7 +577,9 @@ pub struct Solution {
     pub p90e_rad: f32,
     /// Maximum angular residual (radians).
     pub max_err_rad: f32,
-    /// False-positive probability (lower is better).
+    /// False-positive probability of the accepted match (lower is better):
+    /// the verification p-value after the multiple-comparison correction
+    /// that was tested against [`SolveConfig::match_threshold`].
     pub prob: f64,
     /// Wall-clock time spent solving, in milliseconds.
     pub solve_time_ms: f32,

--- a/src/solver/solve.rs
+++ b/src/solver/solve.rs
@@ -177,8 +177,14 @@ impl SolverDatabase {
         let fov_values = build_fov_sweep(
             config.fov_estimate_rad(),
             config.fov_max_error_rad,
-            config.match_radius,
+            self.props.pattern_max_error,
+            diagonal_factor(config),
         );
+
+        // Number of candidate attitudes verified so far across the whole
+        // sweep — the divisor of the sequential multiple-comparison
+        // correction in `solve_at_fov`.
+        let mut candidates_tested: u64 = 0;
 
         debug!(
             "FOV sweep: {} values from {:.2}° to {:.2}°",
@@ -214,6 +220,7 @@ impl SolverDatabase {
                 config,
                 fov_try,
                 &star_vecs,
+                &mut candidates_tested,
                 t0,
             );
             match result {
@@ -233,7 +240,10 @@ impl SolverDatabase {
     ///
     /// `sorted_indices` is the brightness-sorted centroid index order, computed
     /// once by the caller (it does not depend on the FOV). The caller also
-    /// guarantees at least `PATTERN_SIZE` centroids.
+    /// guarantees at least `PATTERN_SIZE` centroids. `candidates_tested`
+    /// accumulates the number of verified candidates across the caller's
+    /// whole FOV sweep (see the acceptance test in the candidate loop).
+    #[allow(clippy::too_many_arguments)]
     fn solve_at_fov(
         &self,
         centroids: &[Centroid],
@@ -241,6 +251,7 @@ impl SolverDatabase {
         config: &SolveConfig,
         fov_estimate: f32,
         star_vectors: &[[f32; 3]],
+        candidates_tested: &mut u64,
         t0: Instant,
     ) -> SolveResult {
         #[cfg(feature = "profile")]
@@ -265,6 +276,11 @@ impl SolverDatabase {
         // Lazily-created x-flipped copy for parity-flipped images.
         // Built on first use, cached for subsequent pattern attempts.
         let mut flipped_vectors: Option<Vec<[f32; 3]>> = None;
+
+        // Scratch buffer for centroid vectors rebuilt at a candidate's
+        // measured FOV (see the rebuild step in the candidate loop). Reused
+        // across candidates to avoid per-candidate allocation.
+        let mut rebuilt_vectors: Vec<[f32; 3]> = Vec::new();
 
         // ── Cluster-buster thinning ──
         // Apply the same separation constraint as database generation to avoid
@@ -341,13 +357,11 @@ impl SolverDatabase {
         } else {
             p_max_err
         };
-        let match_threshold = config.match_threshold / self.props.num_patterns as f64;
         let timeout_ms = config.solve_timeout_ms;
 
-        // Guard against a corrupt or placeholder database. An empty table makes
-        // the hash-probe arithmetic below divide by zero; `num_patterns == 0`
-        // (with a non-empty table) makes `match_threshold` above `+inf`, so
-        // every candidate would pass verification and produce a bogus solution.
+        // Guard against a corrupt or placeholder database. An empty table
+        // makes the hash-probe arithmetic below divide by zero; a non-empty
+        // table claiming zero generated patterns is inconsistent.
         let table_len = self.pattern_catalog.len() as u64;
         if table_len == 0 || self.props.num_patterns == 0 {
             return failure(SolveStatus::NoMatch, t0);
@@ -484,14 +498,54 @@ impl SolverDatabase {
                     // Refine FOV estimate from this match
                     let fov = cat_largest_edge / image_largest_edge * fov_estimate;
 
+                    // ── Rebuild vectors at the measured scale when the sweep
+                    // value is meaningfully off ──
+                    // Edge-ratio keys cancel a pixel-scale error to first
+                    // order, but the SVD attitude and verification residuals
+                    // do not: vectors built at a wrong scale stretch the field
+                    // radially by ε·θ, which overwhelms the verification match
+                    // radius (match_radius·fov) long before the ratio
+                    // tolerance is threatened. Rebuilding at this candidate's
+                    // measured FOV makes a single sweep pass robust to any
+                    // FOV-estimate error within `fov_max_error` (this is what
+                    // lets `build_fov_sweep` use a coarse, pattern-tolerance-
+                    // derived step).
+                    //
+                    // Rebuilding also *registers* accepted solutions better —
+                    // even at sub-percent mismatches the measured scale beats
+                    // the swept one for the match set handed to refinement
+                    // (measured on the TESS multi-sector calibration: pass-1
+                    // fits are ~2× tighter with the rebuild than without).
+                    // Skipped only when the mismatch is negligible — at
+                    // threshold, the residual at the half-diagonal (~0.7·fov)
+                    // is ≲ 0.2 of the match radius — so a well-estimated
+                    // field pays nothing.
+                    let scale_mismatch = (fov / fov_estimate - 1.0).abs();
+                    let rebuild = scale_mismatch > 0.25 * config.match_radius;
+                    let (pat_vecs, ps_meas): ([[f32; 3]; 4], f32) = if rebuild {
+                        let ps = pixel_scale_from_fov(config.image_width(), fov as f64) as f32;
+                        (
+                            std::array::from_fn(|k| {
+                                unit_vector_from_pixels(
+                                    &centroids[sorted_indices[image_pattern_local[k]]],
+                                    ps,
+                                    1.0,
+                                )
+                            }),
+                            ps,
+                        )
+                    } else {
+                        (image_vecs, pixel_scale)
+                    };
+
                     // Sort image pattern by centroid distance (canonical ordering)
                     let mut img_order: [usize; 4] = [0, 1, 2, 3];
-                    sort_pattern_by_centroid_distance(&mut img_order, |i| image_vecs[i]);
+                    sort_pattern_by_centroid_distance(&mut img_order, |i| pat_vecs[i]);
 
                     // Catalog pattern is already pre-sorted during database generation.
                     // Build matched vector pairs.
                     let matched_img: [[f32; 3]; 4] =
-                        std::array::from_fn(|i| image_vecs[img_order[i]]);
+                        std::array::from_fn(|i| pat_vecs[img_order[i]]);
                     let matched_cat: [[f32; 3]; 4] = std::array::from_fn(|i| cat_vecs[i]);
 
                     #[cfg(feature = "profile")]
@@ -536,20 +590,41 @@ impl SolverDatabase {
                         rotation_matrix[(0, 0)] = -rotation_matrix[(0, 0)];
                         rotation_matrix[(0, 1)] = -rotation_matrix[(0, 1)];
                         rotation_matrix[(0, 2)] = -rotation_matrix[(0, 2)];
+                    } else {
+                        parity_flip = false;
+                    }
+                    if rebuild {
+                        // Rebuild the full verification set at the measured
+                        // scale (parity applied directly via the x-sign).
+                        let sign = if parity_flip { -1.0f32 } else { 1.0 };
+                        rebuilt_vectors.clear();
+                        rebuilt_vectors.extend(
+                            sorted_indices
+                                .iter()
+                                .map(|&i| unit_vector_from_pixels(&centroids[i], ps_meas, sign)),
+                        );
+                        working_vectors = &rebuilt_vectors;
+                    } else if parity_flip {
                         // Lazily create flipped centroid vectors for matching
-                        let fv = flipped_vectors.get_or_insert_with(|| {
+                        working_vectors = flipped_vectors.get_or_insert_with(|| {
                             centroid_vectors
                                 .iter()
                                 .map(|v| [-v[0], v[1], v[2]])
                                 .collect()
                         });
-                        working_vectors = fv;
                     } else {
-                        parity_flip = false;
                         working_vectors = &centroid_vectors;
                     }
 
                     // ── Verify by matching nearby catalog stars ──
+                    // The pattern stars that fall inside the tested
+                    // (brightest `match_centroid_count`) set are
+                    // hypothesis-forming, not evidence — exclude them from
+                    // the binomial (see `verify_attitude`).
+                    let hypothesis = image_pattern_local
+                        .iter()
+                        .filter(|&&i| i < match_centroid_count)
+                        .count();
                     let (current_matches, prob_mismatch) = self.verify_attitude(
                         &rotation_matrix,
                         working_vectors,
@@ -557,16 +632,28 @@ impl SolverDatabase {
                         fov,
                         config,
                         star_vectors,
+                        hypothesis,
+                        None,
                     );
 
-                    if prob_mismatch >= match_threshold {
+                    // ── Pre-gate ──
+                    // Every verified candidate consumes one unit of the
+                    // multiple-comparison budget (`candidates_tested` is the
+                    // sequential-Bonferroni divisor of the acceptance test
+                    // below). The pre-gate itself is deliberately *uncorrected*:
+                    // it only decides whether the candidate is promising
+                    // enough to refine — acceptance happens after
+                    // re-verification of the refined attitude.
+                    *candidates_tested += 1;
+                    if prob_mismatch >= config.match_threshold {
                         continue;
                     }
 
                     debug!(
-                        "MATCH: {} matches, prob={:.2e}, fov={:.3}°",
+                        "Candidate {}: {} matches, p={:.2e}, fov={:.3}° — refining",
+                        *candidates_tested,
                         current_matches.len(),
-                        prob_mismatch * self.props.num_patterns as f64,
+                        prob_mismatch,
                         fov.to_degrees()
                     );
 
@@ -579,7 +666,7 @@ impl SolverDatabase {
                     // match measures the true scale, and the model's f is only
                     // a search seed here. Fewer than 4 surviving matches → try
                     // next candidate.
-                    if let Some(result) = self.refine_and_finalize(
+                    let Some(mut result) = self.refine_and_finalize(
                         &rotation_matrix,
                         &current_matches,
                         centroids,
@@ -591,11 +678,81 @@ impl SolverDatabase {
                         pixel_scale_from_fov(config.image_width(), fov as f64),
                         match_centroid_count,
                         4,
-                        prob_mismatch * self.props.num_patterns as f64,
+                        prob_mismatch,
                         t0,
-                    ) {
-                        return Ok(result);
+                    ) else {
+                        continue;
+                    };
+
+                    // ── Post-refinement verification (the acceptance test) ──
+                    // A 4-star SVD attitude can be several match-radii off at
+                    // the field edges (small quads amplify centroid noise), so
+                    // a *true* candidate in a dense field may verify weakly
+                    // (e.g. 14 of 50) — indistinguishable from a lucky false
+                    // candidate by p-value alone. Re-verify with the refined
+                    // attitude: the 3-DOF fit converges to the true attitude
+                    // from those matches and the match count jumps (its
+                    // p-value collapses by tens of orders), while a false
+                    // candidate's coincidences cannot be aligned by 3 DOF and
+                    // its p-value stays ~1. Acceptance applies the sequential
+                    // Bonferroni correction over all candidates tested this
+                    // solve: p·k < match_threshold. The total false-accept
+                    // probability of a full search is bounded by
+                    // match_threshold·ln(k), while early candidates face a
+                    // threshold 5-7 orders looser than the previous
+                    // `/ num_patterns` over-correction, which made clean
+                    // sparse fields (< ~7 stars) mathematically unsolvable.
+                    let refined_rotation = wcs_refine::rotation_from_theta_crval(
+                        result.theta_rad,
+                        result.crval_rad[0],
+                        result.crval_rad[1],
+                    );
+                    // Re-verify at a radius tied to the refined fit quality
+                    // instead of the (coarse) search radius: true matches sit
+                    // within a few RMSE of the refined attitude, while a
+                    // false candidate's coincidences are uniform across the
+                    // search radius, so tightening the radius multiplies each
+                    // match's evidence by (search/refined)² — this is what
+                    // separates a true 14-of-50 dense-field candidate (many
+                    // bright centroids simply absent from the catalog) from a
+                    // lucky false one. Floored at 2.5 px (the refinement's own
+                    // adaptive-radius floor) and never looser than the search
+                    // radius.
+                    let ps_refined = (1.0 / result.camera_model.focal_length_px) as f32;
+                    let refined_radius = (5.0 * result.rmse_rad)
+                        .max(2.5 * ps_refined)
+                        .min(config.match_radius * result.fov_rad);
+                    let (refined_matches, p_refined) = self.verify_attitude(
+                        &refined_rotation,
+                        working_vectors,
+                        match_centroid_count,
+                        result.fov_rad,
+                        config,
+                        star_vectors,
+                        hypothesis,
+                        Some(refined_radius),
+                    );
+                    let corrected_prob = p_refined * *candidates_tested as f64;
+                    if corrected_prob >= config.match_threshold {
+                        debug!(
+                            "Candidate {} rejected after refinement: {} → {} matches, corrected p={:.2e}",
+                            *candidates_tested,
+                            current_matches.len(),
+                            refined_matches.len(),
+                            corrected_prob,
+                        );
+                        continue;
                     }
+
+                    debug!(
+                        "MATCH: {} verified matches (candidate {}), corrected p={:.2e}, fov={:.3}°",
+                        refined_matches.len(),
+                        *candidates_tested,
+                        corrected_prob,
+                        result.fov_rad.to_degrees()
+                    );
+                    result.prob = corrected_prob;
+                    return Ok(result);
                 }
             }
         }
@@ -614,8 +771,23 @@ impl SolverDatabase {
     /// is unchanged by aberration.
     ///
     /// Returns the matches `(centroid_local_idx, catalog_star_idx)` and the
-    /// binomial false-positive probability of the match count (before any
-    /// Bonferroni correction for the number of pattern trials).
+    /// binomial false-positive probability of the match count (a per-candidate
+    /// p-value, before any multiple-comparison correction by the caller).
+    ///
+    /// `hypothesis_matches` is the number of *tested* centroids that were used
+    /// to form the attitude hypothesis (LIS passes the pattern stars that fall
+    /// inside the tested set; tracking passes 0 — its hint is independent of
+    /// the centroids). Those stars match by construction — with the
+    /// measured-FOV rebuild they fit near-exactly, handing every
+    /// ratio-passing candidate "free" matches — so they are excluded from
+    /// both the binomial trials and successes rather than counted as
+    /// evidence. This replaces the upstream-tetra3 heuristic of discounting a
+    /// flat 2 matches.
+    /// `match_radius_rad_override` replaces the default matching radius
+    /// (`config.match_radius · fov`) — the false-positive model scales with
+    /// it, so a tighter radius (e.g. derived from a refined fit's RMSE) makes
+    /// every true match worth quadratically more evidence.
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn verify_attitude(
         &self,
         rotation_matrix: &Matrix3<f32>,
@@ -624,9 +796,11 @@ impl SolverDatabase {
         fov: f32,
         config: &SolveConfig,
         star_vectors: &[[f32; 3]],
+        hypothesis_matches: usize,
+        match_radius_rad_override: Option<f32>,
     ) -> (Vec<(usize, usize)>, f64) {
         let fov_diagonal = fov * diagonal_factor(config);
-        let match_radius_rad = config.match_radius * fov;
+        let match_radius_rad = match_radius_rad_override.unwrap_or(config.match_radius * fov);
 
         // Find catalog stars within the diagonal FOV
         let image_center_icrs = rotation_matrix.transpose() * Vector3::from_array([0.0, 0.0, 1.0]);
@@ -653,7 +827,6 @@ impl SolverDatabase {
         }
         // Limit to 2x the number of image centroids (like tetra3)
         nearby_cam_positions.truncate(2 * match_centroid_count);
-        let num_nearby = nearby_cam_positions.len();
 
         // Match image centroids to projected catalog stars
         let matches = timed!(
@@ -665,11 +838,40 @@ impl SolverDatabase {
             )
         );
 
-        // False-positive probability of this match count
-        let prob_single = num_nearby as f64 * (config.match_radius as f64).powi(2);
+        // False-positive probability of this match count.
+        //
+        // `prob_single` is the chance that a *coincidental* (wrong-attitude)
+        // centroid lands within `match_radius_rad` of some projected catalog
+        // star. Each projected star owns a disc of area π·r², and the
+        // prediction density is *measured* rather than modeled: count the
+        // predictions that could match an in-frame centroid (inside the frame
+        // plus a match-radius margin) and divide by that region's area, all
+        // in tangent-plane units. Measuring the density avoids two opposite
+        // errors that both showed up empirically: upstream tetra3's
+        // `num_nearby·mr²` (no π, cone counted as if spread over the frame)
+        // under-predicts the coincidence rate ~2-3× per match — false
+        // dense-field candidates scored as near-certainties — while
+        // π·num_nearby·mr² over-predicts it by the cone/frame area ratio,
+        // rejecting true candidates in catalog-saturated fields where the
+        // expected coincidence count is a large fraction of the centroids.
+        let half_x = ((fov as f64) / 2.0).tan();
+        let half_y = half_x * (config.image_height() as f64 / config.image_width().max(1) as f64);
+        let margin = match_radius_rad as f64;
+        let n_in = nearby_cam_positions
+            .iter()
+            .filter(|&&(_, x, y)| {
+                (x as f64).abs() <= half_x + margin && (y as f64).abs() <= half_y + margin
+            })
+            .count();
+        let region_area = (2.0 * (half_x + margin)) * (2.0 * (half_y + margin));
+        let prob_single = n_in as f64 * std::f64::consts::PI * margin * margin / region_area;
+        // Exclude hypothesis stars from trials and successes (see doc above).
+        let h = hypothesis_matches.min(match_centroid_count);
+        let trials = match_centroid_count - h;
+        let evidence = matches.len().saturating_sub(h).min(trials);
         let prob_mismatch = binomial_cdf(
-            (match_centroid_count as i64 - (matches.len() as i64 - 2)).max(0) as u32,
-            match_centroid_count as u32,
+            (trials - evidence) as u32,
+            trials as u32,
             1.0 - prob_single.min(1.0),
         );
 
@@ -849,25 +1051,46 @@ impl SolverDatabase {
 
 /// Build FOV values to try: exact estimate first, then spiraling outward.
 ///
-/// Step size is chosen so that the verification match_radius can tolerate the
-/// worst-case scale error at the midpoint between steps.
-fn build_fov_sweep(fov_estimate: f32, fov_max_error: Option<f32>, match_radius: f32) -> Vec<f32> {
+/// The swept value only enters the pattern search through the pixel scale
+/// used to build centroid unit vectors, and pattern keys are *edge ratios*,
+/// so a scale error cancels to first order. Everything downstream
+/// self-corrects: the FOV-consistency filter compares the implied FOV (nearly
+/// independent of the swept value) against the full `fov_max_error`, and the
+/// SVD/verification/refinement all run on vectors rebuilt at the FOV
+/// *measured* from each matched pattern (`cat_largest/image_largest ·
+/// fov_try` — see the rebuild step in the candidate loop).
+///
+/// What remains is the second-order tangent-plane nonlinearity: a relative
+/// scale error ε perturbs edge ratios by ≈ (θ_hd²/3)·ε, where θ_hd is the
+/// half-diagonal angle. The step is sized so that at the midpoint between
+/// sweep values this drift stays within the database's ratio quantization
+/// tolerance:
+///
+///   step ≈ pattern_max_error / (θ_hd²/3) · fov_estimate
+///
+/// (midpoint drift ≤ pattern_max_error/2, leaving the other half of the
+/// search tolerance for centroid noise). At 10° FOV with the default 0.003
+/// tolerance this gives step ≈ 0.6·fov — a single sweep value covers ±2° —
+/// while at very wide FOV (θ_hd large) the sweep stays fine enough to keep
+/// quantization drift bounded.
+fn build_fov_sweep(
+    fov_estimate: f32,
+    fov_max_error: Option<f32>,
+    pattern_max_error: f32,
+    diag_factor: f32,
+) -> Vec<f32> {
     let mut values = vec![fov_estimate];
 
     if let Some(max_error) = fov_max_error {
         if max_error > 0.0 {
-            // Step = 4 * match_radius * fov_estimate.
-            // At the midpoint between steps the relative scale error is
-            // step/(2·fov) = 2·mr. A star at the field edge then has position
-            // error ≈ 2·mr · (fov/2) = mr·fov — right at the verification
-            // match radius (match_radius_rad = mr·fov) — and every star
-            // inboard of the edge proportionally less, so verification still
-            // matches most of the field. Measured on the profile harness
-            // (10° FOV, mr = 0.01, `T3_FOV_BIAS`): a 2% scale error solves
-            // 100% of fields and 3% solves 99%, so the 2·mr = 2% midpoint
-            // keeps full solve rate while halving the sweep length (the sweep
-            // multiplies no-match / wrong-FOV latency).
-            let step = (4.0 * match_radius * fov_estimate).max(0.001_f32.to_radians());
+            // Half-diagonal angle at the estimated FOV (fov is width-referenced).
+            let theta_hd = ((fov_estimate as f64 / 2.0).tan() * diag_factor as f64).atan();
+            // Second-order ratio-drift coefficient; guarded so a degenerate
+            // (near-zero) FOV yields one huge step rather than a division
+            // blowup.
+            let curvature = (theta_hd * theta_hd / 3.0).max(1e-12);
+            let step_rel = pattern_max_error as f64 / curvature;
+            let step = ((step_rel * fov_estimate as f64) as f32).max(0.001_f32.to_radians());
             let mut offset = step;
             while offset <= max_error {
                 values.push(fov_estimate + offset);
@@ -993,14 +1216,23 @@ pub(super) fn centroid_unit_vectors(
 ) -> Vec<[f32; 3]> {
     sorted_indices
         .iter()
-        .map(|&i| {
-            let x = parity_sign * centroids[i].x * pixel_scale;
-            let y = centroids[i].y * pixel_scale;
-            let z = 1.0f32;
-            let norm = (x * x + y * y + z * z).sqrt();
-            [x / norm, y / norm, z / norm]
-        })
+        .map(|&i| unit_vector_from_pixels(&centroids[i], pixel_scale, parity_sign))
         .collect()
+}
+
+/// Unit vector in the camera frame for a single centroid at the given pixel
+/// scale (rad/px), with optional x-negation for parity-flipped images.
+#[inline]
+pub(super) fn unit_vector_from_pixels(
+    centroid: &Centroid,
+    pixel_scale: f32,
+    parity_sign: f32,
+) -> [f32; 3] {
+    let x = parity_sign * centroid.x * pixel_scale;
+    let y = centroid.y * pixel_scale;
+    let z = 1.0f32;
+    let norm = (x * x + y * y + z * z).sqrt();
+    [x / norm, y / norm, z / norm]
 }
 
 /// Compute the least-squares rotation matrix from paired image/catalog unit

--- a/src/solver/track.rs
+++ b/src/solver/track.rs
@@ -162,6 +162,9 @@ impl SolverDatabase {
         }
 
         // ── Verification (same path as LIS) ──
+        // `hypothesis_matches = 0`: the attitude hypothesis comes from the
+        // caller's hint, not from any of the tested centroids, so every match
+        // is independent evidence.
         let (verify_matches, prob_mismatch) = self.verify_attitude(
             &rotation_matrix,
             &centroid_vectors,
@@ -169,10 +172,12 @@ impl SolverDatabase {
             fov_rad,
             config,
             star_vectors,
+            0,
+            None,
         );
 
-        // Same false-positive probability test as LIS, but without the
-        // /num_patterns Bonferroni division (no pattern-hash trials happened).
+        // Same false-positive probability test as LIS, but without any
+        // multiple-comparison correction (a single candidate is tested).
         if prob_mismatch >= config.match_threshold {
             debug!(
                 "Tracking: verification rejected (matches={}, prob={:.2e})",


### PR DESCRIPTION
## Summary

Stage 2 of the LIS solver work: rebuilds solve acceptance around honest statistics. Stacked on #42 (`fix/robustness-sweep`) — retarget to `main` after #42 merges. No public API changes; solve-acceptance **semantics** change.

Two latent defects in the shipped verification were found (while attempting to collapse the FOV sweep) and were partially canceling each other:

1. **`prob_single = num_nearby·mr²` under-predicts the coincidence rate 2-3× per match** (missing π disc area, cone-vs-frame density conflation). Compounded over k matches this let a wrong-attitude TESS candidate with 113 pure-coincidence matches score as a 10⁻¹⁴ certainty. Masked today only because false candidates verify at a mismatched swept pixel scale.
2. **The `match_threshold / num_patterns` Bonferroni divisor over-corrects by 4-7 orders of magnitude** (the correction belongs over candidates actually tested, not database size), making clean sparse fields (< ~7 stars) mathematically unsolvable and dense-field marginal candidates dependent on defect #1 to pass.

## Changes

- **Measured-density null model** — coincidence probability per match from the *measured* in-frame density of projected catalog stars × π·r². Self-calibrating for any FOV, aspect, truncation, or radius.
- **Hypothesis exclusion** — the 4 pattern stars that formed the candidate are excluded from binomial trials and successes (replaces upstream tetra3's flat "−2"); tracking takes no discount.
- **Sequential Bonferroni** — candidate k accepts at `p·k < match_threshold`; `match_threshold` is now a per-solve false-accept budget (total bounded by a log multiple). `Solution.prob` = corrected p-value.
- **Post-refinement re-verification** — the acceptance test re-verifies the *refined* attitude at a radius tied to the refined RMSE. True candidates' p-values collapse as the radius tightens; false candidates' uniform coincidences can't be aligned by the 3-DOF fit. This is what rescues dense fields (galactic center) where a 4-star SVD attitude matches only a fraction of tested centroids.
- **Measured-FOV rebuild + collapsed sweep** — candidate vectors rebuilt at the pattern-measured FOV (also registers accepted solutions ~2× tighter on distorted TESS frames); the sweep step derives from pattern quantization tolerance (usually 1 value).
- Harness: `T3_MAX_CENTROIDS` (sparse fields) and wrong-attitude checking (an accepted wrong attitude counts as a false positive, not a solve).

## Measured (10° synthetic harness, 1000 fields/scenario unless noted)

| Scenario | Before (stage 1) | After | Wrong-attitude accepts |
|---|---|---|---|
| 6-star fields | **0/1000** (impossible by construction) | **712/1000** | 0 |
| 8-star fields | 918/1000 (test DB; worse at shipped DB size) | 918/1000 | 0 |
| Wrong FOV estimate 1-18% | 21 ms @ 15% | **~34 µs, 100% at every bias** | 0 |
| No-match (random fields) | 12.8 ms | **1.6 ms** | **0 / 1500** |
| Easy solves | 48.6 µs | 45.8 µs | 0 |
| 20 spurious centroids | 74.6 µs | 55.7 µs | 0 |

## Validation

- All suites: 67 unit, integration (1000-field statistical + noisy + tracking + parity), skyview 10/10 — including dense Cygnus/Sagittarius, which *fail* under honest statistics without the post-refinement re-verify — TESS 3/3, doc-tests. `clippy --all-targets --all-features` clean.
- The TESS suite includes one deliberate behavior change: multi-sector calibration pass 1 (uncalibrated strong distortion, `match_radius` 0.005) sector 14 now **times out instead of accepting weak evidence** (~150 matches of 1251 where ~125 are expected by chance). The tiered calibration flow recovers it in pass 2; final quality unchanged (0.44″ WCS agreement, 0.133 px pooled fit). Raising `match_threshold` accepts such marginal solves explicitly.
- The previously-false-accepting TESS field (wrong attitude, 119° off, "149 matches") now solves **correctly** (533 matches at the true attitude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)