### PR TITLE
Centroid extraction: estimator fix, quality gates, matched filter, log-parabola, ~40% speedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### Added — extraction quality gates
+
+- **`max_sharpness`** (both extraction configs): DAOFIND-style hot-pixel /
+  cosmic-ray gate — rejects blobs whose peak sharpness
+  `(peak − mean(8 neighbors))/peak` exceeds the limit, measured on the
+  unfiltered background-subtracted image (so a matched-filter-smeared hot
+  pixel is still caught). Off by default: with a sub-pixel PSF (wide-FOV
+  trackers, e.g. 10° on a 2k sensor) real stars are indistinguishable from
+  hot pixels; enable (~0.7–0.9) only when the PSF spans multiple pixels.
+- **`saturation_level`** (both extraction configs): blobs whose peak reaches
+  the sensor's saturation level skip quadratic sub-pixel peak refinement (a
+  flat-topped or bloomed profile has no meaningful maximum) and keep the
+  center-of-mass position. Off by default.
+
 ### Fixed — CCL-path noise estimator (`sigma_threshold` semantics)
 
 `extract_centroids_from_raw` / `extract_centroids_from_image` (the CCL path)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@
   cosmic-ray gate — rejects blobs whose peak sharpness
   `(peak − mean(8 neighbors))/peak` exceeds the limit, measured on the
   unfiltered background-subtracted image (so a matched-filter-smeared hot
-  pixel is still caught). Off by default: with a sub-pixel PSF (wide-FOV
-  trackers, e.g. 10° on a 2k sensor) real stars are indistinguishable from
-  hot pixels; enable (~0.7–0.9) only when the PSF spans multiple pixels.
+  pixel is still caught). **Defaults to 0.9**, which passes any system whose
+  PSF spans multiple pixels (a critically sampled PSF scores ~0.5, a strongly
+  undersampled one ~0.85, a hot pixel ~1.0). Set `None` for severely
+  undersampled data (PSF FWHM below ~1.5 px, e.g. resampled survey cutouts),
+  where real stars are geometrically indistinguishable from hot pixels.
 - **`saturation_level`** (both extraction configs): blobs whose peak reaches
   the sensor's saturation level skip quadratic sub-pixel peak refinement (a
   flat-topped or bloomed profile has no meaningful maximum) and keep the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,27 @@
   the zero-clamped background-subtracted image, rectifying negative noise
   into a positive DC offset that silently loosened the effective threshold.
 
+### Changed — sub-pixel peak refinement fits log intensity
+
+The 3×3 parabola refinement (both extraction paths) now fits **log**
+intensity when all nine background-subtracted samples are positive: a
+Gaussian PSF is exactly quadratic in `ln(v)`, which removes the linear fit's
+S-curve bias (~0.05–0.1 px at quarter-pixel peak phases). Blobs with
+non-positive samples in the window keep the linear fit. Measured on the TESS
+10-image multi-sector calibration: pooled fit residual 0.132 → 0.077 px
+(−42%) and typical per-sector solve RMSE 2.5–2.9″ → 1.0–1.7″.
+
+### Added — fast-path trail/streak rejection and covariance
+
+`FastCentroidConfig` gains `max_pixels` (default 10000 — without it a
+satellite trail or bloomed region becomes the *brightest* centroid handed to
+the solver) and `max_elongation` (opt-in; moment-based elongation is noisy
+for few-pixel regions). The fast path now accumulates intensity-weighted
+second moments inline (merged through union-find), so it also populates
+`Centroid.cov` like the CCL path. Note the coarse background grid already
+absorbs structure larger than a block (~64 px) before these filters see it;
+`max_pixels` matters for sharp bloomed regions, `max_elongation` for trails.
+
 ### Added — extraction quality gates
 
 - **`max_sharpness`** (both extraction configs): DAOFIND-style hot-pixel /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+### Changed — matched filter on by default, threshold auto-compensated
+
+- **`matched_filter_sigma` defaults to `Some(1.5)`** (was `None`): every
+  serious point-source detector convolves before thresholding; for a
+  σ≈1.5 px PSF the peak-SNR gain is ~2× (≈0.75 mag more detection depth at
+  the same false-positive rate), with a broad optimum (σ within ~2× of the
+  true PSF width). Set `None` to threshold unfiltered.
+- **The detection threshold is now scaled by the kernel's noise-suppression
+  factor** (Σk² of the separable blur), so `sigma_threshold` means "sigmas
+  of the noise actually present in the thresholded image" with the filter on
+  or off — toggling the filter no longer requires retuning the threshold.
+  `ExtractionResult.threshold` reports the threshold actually applied.
+- **The filter now convolves the unclamped residual.** Previously it blurred
+  the zero-clamped background-subtracted image, rectifying negative noise
+  into a positive DC offset that silently loosened the effective threshold.
+
 ### Added — extraction quality gates
 
 - **`max_sharpness`** (both extraction configs): DAOFIND-style hot-pixel /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+### Fixed — CCL-path noise estimator (`sigma_threshold` semantics)
+
+`extract_centroids_from_raw` / `extract_centroids_from_image` (the CCL path)
+underestimated the background noise by ~40%: sigma was computed as the RMS of
+below-median pixels about their *own mean* — for Gaussian noise the lower
+half-distribution has std ≈ 0.60σ — instead of about the *median*, whose
+lower-half second moment equals the full variance (the estimator the
+docstring described, and the one the fast path already used). In practice a
+configured `sigma_threshold: 5.0` was really a ~3σ cut, the two extraction
+paths applied materially different effective thresholds for the same setting,
+and `ExtractionResult.background_sigma` was wrong as a diagnostic.
+
+**Migration:** the CCL path's `sigma_threshold` now means true Gaussian
+sigmas. To keep your previous effective detection depth, multiply configured
+values by ≈0.6 (e.g. `5.0` → `3.0`); leave them unchanged to get the
+threshold you had nominally been asking for. `FastCentroidConfig` is
+unaffected (it was already correct).
+
 ### Changed — verification statistics recalibrated (solve-acceptance semantics)
 
 The lost-in-space acceptance test was rebuilt around honest statistics; no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,14 @@ distortion first (the tiered calibration flow does this automatically).
 
 ### Performance
 
+- **CCL extraction ~40% faster** (71.5 → ~42 ms on 2048² TESS frames,
+  matched filter on). Block medians are computed from a phase-staggered
+  stride subsample; the materialized full-image background buffer and its
+  separate subtraction passes are replaced by one fused pass that
+  interpolates the block grid on the fly (writing the filter's unclamped
+  input directly into the blur matrix); noise statistics run on subsampled
+  bilinear residuals with the same estimator. The fast path hoists the
+  row-constant half of its per-pixel bilinear out of the sweep (~10%).
 - **Faster no-match / wrong-FOV solves.** The FOV sweep step doubled to
   `4·match_radius·fov` — measurements show verification tolerates the full
   match radius of midpoint scale error, so half the sweep values cover the

--- a/python/src/extraction.rs
+++ b/python/src/extraction.rs
@@ -192,10 +192,11 @@ impl PyExtractionResult {
 ///     local_bg_block_size: Block size for local background estimation. None = global only.
 ///     max_elongation: Maximum blob elongation ratio. None = disabled.
 ///     matched_filter_sigma: Apply a Gaussian matched filter of this sigma
-///         (in pixels) before thresholding. Boosts point-source SNR; the
-///         filter is used only to form the detection mask, so photometry
-///         is unaffected. Consider lowering sigma_threshold when enabled.
-///         None = disabled.
+///         (in pixels) before thresholding (~2x point-source SNR for a
+///         sigma~1.5 px PSF). Used only to form the detection mask, so
+///         photometry is unaffected, and the threshold is automatically
+///         scaled for the filtered noise level — no retuning needed.
+///         None = disabled. Default 1.5.
 ///     max_sharpness: Reject blobs whose peak sharpness
 ///         ``(peak - mean(8 neighbors)) / peak`` exceeds this — values near 1
 ///         are hot pixels / cosmic rays, not stars. A critically sampled PSF
@@ -219,7 +220,7 @@ impl PyExtractionResult {
     max_centroids = None,
     local_bg_block_size = Some(64),
     max_elongation = Some(3.0),
-    matched_filter_sigma = None,
+    matched_filter_sigma = Some(1.5),
     max_sharpness = Some(0.9),
     saturation_level = None,
 ))]

--- a/python/src/extraction.rs
+++ b/python/src/extraction.rs
@@ -196,6 +196,16 @@ impl PyExtractionResult {
 ///         filter is used only to form the detection mask, so photometry
 ///         is unaffected. Consider lowering sigma_threshold when enabled.
 ///         None = disabled.
+///     max_sharpness: Reject blobs whose peak sharpness
+///         ``(peak - mean(8 neighbors)) / peak`` exceeds this — values near 1
+///         are hot pixels / cosmic rays, not stars. A critically sampled PSF
+///         scores ~0.5; strongly undersampled optics up to ~0.85; with a
+///         sub-pixel PSF real stars are indistinguishable from hot pixels,
+///         so leave it off. None = disabled (default).
+///     saturation_level: Pixel value at or above which the sensor is
+///         saturated; such blobs skip sub-pixel peak refinement (a flat top
+///         has no meaningful maximum) and keep the center-of-mass position.
+///         None = disabled.
 ///
 /// Returns:
 ///     ExtractionResult with centroids and image statistics.
@@ -209,6 +219,8 @@ impl PyExtractionResult {
     local_bg_block_size = Some(64),
     max_elongation = Some(3.0),
     matched_filter_sigma = None,
+    max_sharpness = None,
+    saturation_level = None,
 ))]
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn extract_centroids(
@@ -220,6 +232,8 @@ pub(crate) fn extract_centroids(
     local_bg_block_size: Option<u32>,
     max_elongation: Option<f32>,
     matched_filter_sigma: Option<f32>,
+    max_sharpness: Option<f32>,
+    saturation_level: Option<f32>,
 ) -> PyResult<PyExtractionResult> {
     let (pixels, width, height) = image_to_f32(image)?;
 
@@ -234,6 +248,8 @@ pub(crate) fn extract_centroids(
         local_bg_block_size,
         max_elongation,
         matched_filter_sigma,
+        max_sharpness,
+        saturation_level,
     };
 
     let result =
@@ -269,6 +285,14 @@ pub(crate) fn extract_centroids(
 ///     min_pixels: Minimum pixels in a region (rejects hot pixels). Default 2.
 ///     max_centroids: Maximum number of centroids to return, brightest first.
 ///         None = all. A few dozen is plenty for solving / tracking.
+///     max_sharpness: Reject regions whose peak sharpness
+///         ``(peak - mean(8 neighbors)) / peak`` exceeds this — values near 1
+///         are hot pixels / cosmic rays, not stars; with a sub-pixel PSF
+///         real stars are indistinguishable, so leave it off.
+///         None = disabled (default).
+///     saturation_level: Pixel value at or above which the sensor is
+///         saturated; such regions skip sub-pixel peak refinement and keep
+///         the center-of-mass position. None = disabled.
 ///
 /// Returns:
 ///     ExtractionResult with centroids and image statistics.
@@ -279,13 +303,18 @@ pub(crate) fn extract_centroids(
     bg_grid = 64,
     min_pixels = 2,
     max_centroids = None,
+    max_sharpness = None,
+    saturation_level = None,
 ))]
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn extract_centroids_fast(
     image: &Bound<'_, pyo3::PyAny>,
     sigma_threshold: f32,
     bg_grid: u32,
     min_pixels: usize,
     max_centroids: Option<usize>,
+    max_sharpness: Option<f32>,
+    saturation_level: Option<f32>,
 ) -> PyResult<PyExtractionResult> {
     let (pixels, width, height) = image_to_f32(image)?;
 
@@ -294,6 +323,8 @@ pub(crate) fn extract_centroids_fast(
         bg_grid,
         min_pixels,
         max_centroids,
+        max_sharpness,
+        saturation_level,
     };
 
     let result =

--- a/python/src/extraction.rs
+++ b/python/src/extraction.rs
@@ -199,9 +199,10 @@ impl PyExtractionResult {
 ///     max_sharpness: Reject blobs whose peak sharpness
 ///         ``(peak - mean(8 neighbors)) / peak`` exceeds this — values near 1
 ///         are hot pixels / cosmic rays, not stars. A critically sampled PSF
-///         scores ~0.5; strongly undersampled optics up to ~0.85; with a
-///         sub-pixel PSF real stars are indistinguishable from hot pixels,
-///         so leave it off. None = disabled (default).
+///         scores ~0.5; strongly undersampled optics up to ~0.85. Set to
+///         None for severely undersampled data (PSF FWHM below ~1.5 px),
+///         where real stars are indistinguishable from hot pixels.
+///         Default 0.9.
 ///     saturation_level: Pixel value at or above which the sensor is
 ///         saturated; such blobs skip sub-pixel peak refinement (a flat top
 ///         has no meaningful maximum) and keep the center-of-mass position.
@@ -219,7 +220,7 @@ impl PyExtractionResult {
     local_bg_block_size = Some(64),
     max_elongation = Some(3.0),
     matched_filter_sigma = None,
-    max_sharpness = None,
+    max_sharpness = Some(0.9),
     saturation_level = None,
 ))]
 #[allow(clippy::too_many_arguments)]
@@ -287,9 +288,9 @@ pub(crate) fn extract_centroids(
 ///         None = all. A few dozen is plenty for solving / tracking.
 ///     max_sharpness: Reject regions whose peak sharpness
 ///         ``(peak - mean(8 neighbors)) / peak`` exceeds this — values near 1
-///         are hot pixels / cosmic rays, not stars; with a sub-pixel PSF
-///         real stars are indistinguishable, so leave it off.
-///         None = disabled (default).
+///         are hot pixels / cosmic rays, not stars. Set to None for
+///         severely undersampled data (PSF FWHM below ~1.5 px).
+///         Default 0.9.
 ///     saturation_level: Pixel value at or above which the sensor is
 ///         saturated; such regions skip sub-pixel peak refinement and keep
 ///         the center-of-mass position. None = disabled.
@@ -303,7 +304,7 @@ pub(crate) fn extract_centroids(
     bg_grid = 64,
     min_pixels = 2,
     max_centroids = None,
-    max_sharpness = None,
+    max_sharpness = Some(0.9),
     saturation_level = None,
 ))]
 #[allow(clippy::too_many_arguments)]

--- a/python/src/extraction.rs
+++ b/python/src/extraction.rs
@@ -295,6 +295,14 @@ pub(crate) fn extract_centroids(
 ///     saturation_level: Pixel value at or above which the sensor is
 ///         saturated; such regions skip sub-pixel peak refinement and keep
 ///         the center-of-mass position. None = disabled.
+///     max_pixels: Maximum region size in pixels — without it a satellite
+///         trail or horizon glow becomes the *brightest* centroid handed to
+///         the solver. Default 10000.
+///     max_elongation: Maximum elongation ratio (major/minor axis) from
+///         intensity-weighted second moments — rejects streaks too small for
+///         max_pixels. Off by default: moment-based elongation is noisy for
+///         regions of a few pixels; enable (3.0-5.0) with min_pixels raised
+///         to ~5+. None = disabled.
 ///
 /// Returns:
 ///     ExtractionResult with centroids and image statistics.
@@ -307,6 +315,8 @@ pub(crate) fn extract_centroids(
     max_centroids = None,
     max_sharpness = Some(0.9),
     saturation_level = None,
+    max_pixels = 10000,
+    max_elongation = None,
 ))]
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn extract_centroids_fast(
@@ -317,6 +327,8 @@ pub(crate) fn extract_centroids_fast(
     max_centroids: Option<usize>,
     max_sharpness: Option<f32>,
     saturation_level: Option<f32>,
+    max_pixels: usize,
+    max_elongation: Option<f32>,
 ) -> PyResult<PyExtractionResult> {
     let (pixels, width, height) = image_to_f32(image)?;
 
@@ -327,6 +339,8 @@ pub(crate) fn extract_centroids_fast(
         max_centroids,
         max_sharpness,
         saturation_level,
+        max_pixels,
+        max_elongation,
     };
 
     let result =

--- a/python/tests/test_skyview.py
+++ b/python/tests/test_skyview.py
@@ -41,7 +41,7 @@ class TestSkyViewSolve:
         # Extract centroids
         result = tetra3rs.extract_centroids(
             image,
-            sigma_threshold=10.0,
+            sigma_threshold=6.0,
             min_pixels=3,
             max_pixels=10000,
             max_centroids=200,

--- a/python/tests/test_skyview.py
+++ b/python/tests/test_skyview.py
@@ -47,6 +47,10 @@ class TestSkyViewSolve:
             max_centroids=200,
             local_bg_block_size=64,
             max_elongation=3.0,
+            # DSS cutouts at 17.6"/px have a sub-pixel PSF: real stars are
+            # indistinguishable from hot pixels, so the sharpness gate must
+            # be off for this (edge-case) plate scale.
+            max_sharpness=None,
         )
         assert len(result.centroids) >= 4, (
             f"Only {len(result.centroids)} centroids extracted"

--- a/python/tetra3rs/__init__.pyi
+++ b/python/tetra3rs/__init__.pyi
@@ -1133,6 +1133,8 @@ def extract_centroids_fast(
     max_centroids: Optional[int] = None,
     max_sharpness: Optional[float] = 0.9,
     saturation_level: Optional[float] = None,
+    max_pixels: int = 10000,
+    max_elongation: Optional[float] = None,
 ) -> ExtractionResult:
     """Fast single-pass centroid extraction — the "adequate star tracker" path.
 
@@ -1161,6 +1163,13 @@ def extract_centroids_fast(
         saturation_level: Pixel value at or above which the sensor is
             saturated; such regions skip sub-pixel peak refinement and keep
             the center-of-mass position. None = disabled.
+        max_pixels: Maximum region size in pixels — without it a satellite
+            trail or horizon glow becomes the *brightest* centroid handed to
+            the solver.
+        max_elongation: Maximum elongation ratio (major/minor axis) from
+            intensity-weighted second moments — rejects streaks too small
+            for max_pixels. Off by default (noisy for few-pixel regions);
+            enable (3.0-5.0) with min_pixels raised to ~5+. None = disabled.
 
     Returns:
         ExtractionResult with centroids and image statistics.

--- a/python/tetra3rs/__init__.pyi
+++ b/python/tetra3rs/__init__.pyi
@@ -1087,7 +1087,7 @@ def extract_centroids(
     local_bg_block_size: Optional[int] = 64,
     max_elongation: Optional[float] = 3.0,
     matched_filter_sigma: Optional[float] = None,
-    max_sharpness: Optional[float] = None,
+    max_sharpness: Optional[float] = 0.9,
     saturation_level: Optional[float] = None,
 ) -> ExtractionResult:
     """Extract star centroids from a 2D image array.
@@ -1109,9 +1109,10 @@ def extract_centroids(
         max_sharpness: Reject blobs whose peak sharpness
             ``(peak - mean(8 neighbors)) / peak`` exceeds this — values near
             1 are hot pixels / cosmic rays, not stars. A critically sampled
-            PSF scores ~0.5; strongly undersampled optics up to ~0.85; with
-            a sub-pixel PSF real stars are indistinguishable from hot pixels,
-            so leave it off. None = disabled (default).
+            PSF scores ~0.5; strongly undersampled optics up to ~0.85.
+            Set to None for severely undersampled data (PSF FWHM below
+            ~1.5 px), where real stars are indistinguishable from hot
+            pixels. Default 0.9.
         saturation_level: Pixel value at or above which the sensor is
             saturated; such blobs skip sub-pixel peak refinement (a flat top
             has no meaningful maximum) and keep the center-of-mass position.
@@ -1128,7 +1129,7 @@ def extract_centroids_fast(
     bg_grid: int = 64,
     min_pixels: int = 2,
     max_centroids: Optional[int] = None,
-    max_sharpness: Optional[float] = None,
+    max_sharpness: Optional[float] = 0.9,
     saturation_level: Optional[float] = None,
 ) -> ExtractionResult:
     """Fast single-pass centroid extraction — the "adequate star tracker" path.
@@ -1152,9 +1153,9 @@ def extract_centroids_fast(
             None = all.
         max_sharpness: Reject regions whose peak sharpness
             ``(peak - mean(8 neighbors)) / peak`` exceeds this — values near
-            1 are hot pixels / cosmic rays, not stars; with a sub-pixel
-            PSF real stars are indistinguishable, so leave it off.
-            None = disabled (default).
+            1 are hot pixels / cosmic rays, not stars. Set to None for
+            severely undersampled data (PSF FWHM below ~1.5 px).
+            Default 0.9.
         saturation_level: Pixel value at or above which the sensor is
             saturated; such regions skip sub-pixel peak refinement and keep
             the center-of-mass position. None = disabled.

--- a/python/tetra3rs/__init__.pyi
+++ b/python/tetra3rs/__init__.pyi
@@ -1086,7 +1086,7 @@ def extract_centroids(
     max_centroids: Optional[int] = None,
     local_bg_block_size: Optional[int] = 64,
     max_elongation: Optional[float] = 3.0,
-    matched_filter_sigma: Optional[float] = None,
+    matched_filter_sigma: Optional[float] = 1.5,
     max_sharpness: Optional[float] = 0.9,
     saturation_level: Optional[float] = None,
 ) -> ExtractionResult:
@@ -1103,9 +1103,11 @@ def extract_centroids(
             None = global background only.
         max_elongation: Maximum blob elongation ratio. None = disabled.
         matched_filter_sigma: Apply a Gaussian matched filter of this sigma
-            (in pixels) before thresholding. Boosts point-source SNR; used
-            only to form the detection mask so photometry is unaffected.
-            Consider lowering sigma_threshold when enabled. None = disabled.
+            (in pixels) before thresholding (~2x point-source SNR for a
+            sigma~1.5 px PSF). Used only to form the detection mask, so
+            photometry is unaffected, and the threshold is automatically
+            scaled for the filtered noise level — no retuning needed.
+            None = disabled. Default 1.5.
         max_sharpness: Reject blobs whose peak sharpness
             ``(peak - mean(8 neighbors)) / peak`` exceeds this — values near
             1 are hot pixels / cosmic rays, not stars. A critically sampled

--- a/python/tetra3rs/__init__.pyi
+++ b/python/tetra3rs/__init__.pyi
@@ -1087,6 +1087,8 @@ def extract_centroids(
     local_bg_block_size: Optional[int] = 64,
     max_elongation: Optional[float] = 3.0,
     matched_filter_sigma: Optional[float] = None,
+    max_sharpness: Optional[float] = None,
+    saturation_level: Optional[float] = None,
 ) -> ExtractionResult:
     """Extract star centroids from a 2D image array.
 
@@ -1104,6 +1106,16 @@ def extract_centroids(
             (in pixels) before thresholding. Boosts point-source SNR; used
             only to form the detection mask so photometry is unaffected.
             Consider lowering sigma_threshold when enabled. None = disabled.
+        max_sharpness: Reject blobs whose peak sharpness
+            ``(peak - mean(8 neighbors)) / peak`` exceeds this — values near
+            1 are hot pixels / cosmic rays, not stars. A critically sampled
+            PSF scores ~0.5; strongly undersampled optics up to ~0.85; with
+            a sub-pixel PSF real stars are indistinguishable from hot pixels,
+            so leave it off. None = disabled (default).
+        saturation_level: Pixel value at or above which the sensor is
+            saturated; such blobs skip sub-pixel peak refinement (a flat top
+            has no meaningful maximum) and keep the center-of-mass position.
+            None = disabled.
 
     Returns:
         ExtractionResult with centroids and image statistics.
@@ -1116,6 +1128,8 @@ def extract_centroids_fast(
     bg_grid: int = 64,
     min_pixels: int = 2,
     max_centroids: Optional[int] = None,
+    max_sharpness: Optional[float] = None,
+    saturation_level: Optional[float] = None,
 ) -> ExtractionResult:
     """Fast single-pass centroid extraction — the "adequate star tracker" path.
 
@@ -1136,6 +1150,14 @@ def extract_centroids_fast(
         min_pixels: Minimum pixels in a region; rejects hot pixels.
         max_centroids: Maximum number of centroids to return, brightest first.
             None = all.
+        max_sharpness: Reject regions whose peak sharpness
+            ``(peak - mean(8 neighbors)) / peak`` exceeds this — values near
+            1 are hot pixels / cosmic rays, not stars; with a sub-pixel
+            PSF real stars are indistinguishable, so leave it off.
+            None = disabled (default).
+        saturation_level: Pixel value at or above which the sensor is
+            saturated; such regions skip sub-pixel peak refinement and keep
+            the center-of-mass position. None = disabled.
 
     Returns:
         ExtractionResult with centroids and image statistics.

--- a/src/centroid_extraction/ccl.rs
+++ b/src/centroid_extraction/ccl.rs
@@ -12,8 +12,8 @@ use numeris::imageproc::{
 use numeris::DynMatrix;
 
 use super::{
-    accepted_peak_refine, median_f32, midpoint_f32, peak_sharpness, sort_and_truncate_by_mass,
-    CentroidExtractionConfig, CentroidExtractionResult,
+    accepted_peak_refine, elongation_from_cov, median_f32, midpoint_f32, peak_sharpness,
+    sort_and_truncate_by_mass, CentroidExtractionConfig, CentroidExtractionResult,
 };
 use crate::centroid::Centroid;
 use crate::error::{Error, Result};
@@ -576,13 +576,7 @@ fn compute_blob_centroids(
                 let cxx = sum_xx / sum_i - dx_bar * dx_bar;
                 let cyy = sum_yy / sum_i - dy_bar * dy_bar;
                 let cxy = sum_xy / sum_i - dx_bar * dy_bar;
-                let trace = cxx + cyy;
-                let det = cxx * cyy - cxy * cxy;
-                let disc = (trace * trace - 4.0 * det).max(0.0).sqrt();
-                let lambda_max = (trace + disc) / 2.0;
-                let lambda_min = (trace - disc).max(1e-12) / 2.0;
-                let elongation = (lambda_max / lambda_min).sqrt() as f32;
-                if elongation > max_elong {
+                if elongation_from_cov(cxx, cyy, cxy) > max_elong {
                     return None;
                 }
             }

--- a/src/centroid_extraction/ccl.rs
+++ b/src/centroid_extraction/ccl.rs
@@ -291,6 +291,20 @@ fn estimate_local_background(pixels: &[f32], width: u32, height: u32, block_size
 
     // Compute median for each block. Blocks are independent and each writes its
     // own index, so this maps in parallel under the `parallel` feature.
+    //
+    // Each block is subsampled on a stride grid rather than exhausted: at the
+    // default 64-px block, stride 4 medians 256 samples instead of 4096. The
+    // block median's standard error (≈1.25σ/√n) stays ≲ 0.08σ — far below
+    // any detection threshold — while the median stage, the dominant cost of
+    // extraction, drops ~16×. (The fast path's `coarse_background` uses the
+    // same trick at stride block/8; block/16 here keeps extra margin since
+    // this path is the calibration-quality one.)
+    //
+    // Only non-finite samples are excluded (NaN-masked regions). Zeros and
+    // negatives are legitimate background samples — excluding them, as this
+    // function once did, biases the background *up* on dark-subtracted
+    // frames whose true background is ~0.
+    let stride = (bs / 16).max(1);
     let block_medians: Vec<f32> = par::map_indices(nx * ny, |bi| {
         let bx = bi % nx;
         let by = bi / nx;
@@ -299,14 +313,29 @@ fn estimate_local_background(pixels: &[f32], width: u32, height: u32, block_size
         let x1 = (x0 + bs).min(w);
         let y1 = (y0 + bs).min(h);
 
-        let mut vals: Vec<f32> = Vec::with_capacity(bs * bs);
-        for y in y0..y1 {
-            for x in x0..x1 {
-                let v = pixels[y * w + x];
-                if v > 0.0 && v.is_finite() {
+        let mut vals: Vec<f32> = Vec::with_capacity((bs / stride + 1).pow(2));
+        let mut y = y0;
+        let mut phase = 0usize;
+        while y < y1 {
+            let row = y * w;
+            // Stagger the column phase per sample row (a diagonal lattice):
+            // a plain stride grid samples only one column-residue class,
+            // which aliases against column-periodic structure (CMOS
+            // fixed-pattern noise, Bayer residue). Cycling the phase covers
+            // every residue class equally across `stride` consecutive sample
+            // rows. (Row-periodic structure with period dividing the stride
+            // still aliases — sample rows are inherently strided — but
+            // column FPN is the dominant periodic artifact in practice.)
+            let mut x = x0 + phase;
+            while x < x1 {
+                let v = pixels[row + x];
+                if v.is_finite() {
                     vals.push(v);
                 }
+                x += stride;
             }
+            phase = (phase + 1) % stride;
+            y += stride;
         }
 
         midpoint_f32(&mut vals)

--- a/src/centroid_extraction/ccl.rs
+++ b/src/centroid_extraction/ccl.rs
@@ -165,28 +165,40 @@ pub(super) fn extract_from_gray(
         Cow::Borrowed(gray_input)
     };
     let (bg_mean, bg_sigma) = estimate_background(&noise_input, width, height, config);
-    let threshold = bg_mean + config.sigma_threshold * bg_sigma;
 
     // ── Step 3: optional matched filter for thresholding only ──
-    // When `matched_filter_sigma` is set, the bg-subtracted residual is
-    // convolved with a Gaussian and threshold/CCL run on the filtered copy.
-    // Centroids are still measured on the unfiltered `gray`, so intensities
-    // and CoM positions are unaffected. Under the `parallel` feature numeris's
+    // When `matched_filter_sigma` is set, the *unclamped* residual is
+    // convolved with a Gaussian and threshold/CCL run on the filtered copy —
+    // blurring the clamped image would rectify negative noise into a
+    // positive DC offset that silently loosens the threshold. Centroids are
+    // still measured on the unfiltered `gray`, so intensities and CoM
+    // positions are unaffected. The detection threshold is scaled by the
+    // kernel's white-noise suppression factor so `sigma_threshold` keeps
+    // meaning "sigmas of the noise actually present in the thresholded
+    // image", filter on or off. Under the `parallel` feature numeris's
     // gaussian_blur runs multi-threaded.
-    let filtered: Option<Vec<f32>> = match config.matched_filter_sigma {
+    let (thresh_src, mask_threshold): (Cow<[f32]>, f32) = match config.matched_filter_sigma {
         Some(sigma) if sigma.is_finite() && sigma > 0.0 => {
-            let mat = DynMatrix::<f32>::from_vec(w, h, gray.to_vec());
-            Some(gaussian_blur(&mat, sigma, BorderMode::Replicate).into_vec())
+            let mat = DynMatrix::<f32>::from_vec(w, h, noise_input.to_vec());
+            let filtered = gaussian_blur(&mat, sigma, BorderMode::Replicate).into_vec();
+            let suppression = gaussian_noise_suppression(sigma);
+            (
+                Cow::Owned(filtered),
+                bg_mean + config.sigma_threshold * bg_sigma * suppression,
+            )
         }
-        _ => None,
+        _ => (
+            Cow::Borrowed(gray),
+            bg_mean + config.sigma_threshold * bg_sigma,
+        ),
     };
-    let thresh_src: &[f32] = filtered.as_deref().unwrap_or(gray);
+    let thresh_src: &[f32] = &thresh_src;
 
     // ── Step 4: threshold and label blobs ──
     // Build a u8 mask DynMatrix in proper (h, w) layout for CCL — its
     // bbox/labels conventions assume the supplied dimensions match the image.
     let mask = DynMatrix::<u8>::from_fn(h, w, |r, c| {
-        if thresh_src[r * w + c] > threshold {
+        if thresh_src[r * w + c] > mask_threshold {
             1u8
         } else {
             0u8
@@ -248,7 +260,7 @@ pub(super) fn extract_from_gray(
         image_height: height,
         background_mean: bg_mean,
         background_sigma: bg_sigma,
-        threshold,
+        threshold: mask_threshold,
         num_blobs_raw,
     })
 }
@@ -333,6 +345,27 @@ fn estimate_local_background(pixels: &[f32], width: u32, height: u32, block_size
     });
 
     background
+}
+
+/// White-noise standard-deviation suppression factor of the separable 2-D
+/// Gaussian blur used by the matched filter.
+///
+/// For a normalized 1-D kernel `k`, convolving white noise multiplies its
+/// standard deviation by `√(Σk²)` per axis, so the separable 2-D factor is
+/// `Σk²`. The kernel is replicated exactly as numeris builds it (radius
+/// `ceil(3σ)`, `exp(−x²/2σ²)` weights, normalized); for σ ≳ 1 this
+/// approaches the continuous limit `1/(2√π·σ)`.
+fn gaussian_noise_suppression(sigma: f32) -> f32 {
+    let radius = (3.0 * sigma).ceil() as i64;
+    let inv_two_sigma_sq = 1.0 / (2.0 * sigma as f64 * sigma as f64);
+    let mut sum = 0.0_f64;
+    let mut sum_sq = 0.0_f64;
+    for i in -radius..=radius {
+        let w = (-((i * i) as f64) * inv_two_sigma_sq).exp();
+        sum += w;
+        sum_sq += w * w;
+    }
+    (sum_sq / (sum * sum)) as f32
 }
 
 /// Estimate background level and noise.

--- a/src/centroid_extraction/ccl.rs
+++ b/src/centroid_extraction/ccl.rs
@@ -38,35 +38,6 @@ mod par {
     #[cfg(feature = "parallel")]
     use rayon::prelude::*;
 
-    /// `(a - b).max(0.0)` element-wise (background subtraction with clamp).
-    #[cfg(feature = "parallel")]
-    pub fn map_subtract_clamp(a: &[f32], b: &[f32]) -> Vec<f32> {
-        a.par_iter()
-            .zip(b.par_iter())
-            .map(|(&v, &bg)| (v - bg).max(0.0))
-            .collect()
-    }
-    #[cfg(not(feature = "parallel"))]
-    pub fn map_subtract_clamp(a: &[f32], b: &[f32]) -> Vec<f32> {
-        a.iter()
-            .zip(b.iter())
-            .map(|(&v, &bg)| (v - bg).max(0.0))
-            .collect()
-    }
-
-    /// `a - b` element-wise (background subtraction, unclamped).
-    #[cfg(feature = "parallel")]
-    pub fn map_subtract(a: &[f32], b: &[f32]) -> Vec<f32> {
-        a.par_iter()
-            .zip(b.par_iter())
-            .map(|(&v, &bg)| v - bg)
-            .collect()
-    }
-    #[cfg(not(feature = "parallel"))]
-    pub fn map_subtract(a: &[f32], b: &[f32]) -> Vec<f32> {
-        a.iter().zip(b.iter()).map(|(&v, &bg)| v - bg).collect()
-    }
-
     /// Map `f` over `0..n` into a `Vec`, preserving index order.
     #[cfg(feature = "parallel")]
     pub fn map_indices<T, F>(n: usize, f: F) -> Vec<T>
@@ -105,6 +76,34 @@ mod par {
             f(i, c);
         }
     }
+
+    /// Apply `f(i, chunk_a, chunk_b)` to corresponding disjoint
+    /// `chunk_len`-sized chunks of two buffers (one image row each).
+    #[cfg(feature = "parallel")]
+    pub fn for_each_chunk_pair_mut<T, U, F>(a: &mut [T], b: &mut [U], chunk_len: usize, f: F)
+    where
+        T: Send,
+        U: Send,
+        F: Fn(usize, &mut [T], &mut [U]) + Sync + Send,
+    {
+        a.par_chunks_mut(chunk_len)
+            .zip(b.par_chunks_mut(chunk_len))
+            .enumerate()
+            .for_each(|(i, (ca, cb))| f(i, ca, cb));
+    }
+    #[cfg(not(feature = "parallel"))]
+    pub fn for_each_chunk_pair_mut<T, U, F>(a: &mut [T], b: &mut [U], chunk_len: usize, mut f: F)
+    where
+        F: FnMut(usize, &mut [T], &mut [U]),
+    {
+        for (i, (ca, cb)) in a
+            .chunks_mut(chunk_len)
+            .zip(b.chunks_mut(chunk_len))
+            .enumerate()
+        {
+            f(i, ca, cb);
+        }
+    }
 }
 
 /// Shared extraction pipeline for both image and raw-pixel entry points.
@@ -139,47 +138,87 @@ pub(super) fn extract_from_gray(
         )));
     }
 
-    // ── Step 1: local background subtraction ──
-    // If local_bg_block_size is set, estimate and subtract a spatially varying
-    // background model. This is critical for images with nebulosity, Milky Way
-    // emission, vignetting, or other large-scale intensity gradients. Without
-    // it the input is used as-is (borrowed — no full-image copies).
+    let filter_sigma = config
+        .matched_filter_sigma
+        .filter(|s| s.is_finite() && *s > 0.0);
+
+    // ── Steps 1-2: background model, residuals, and noise stats ──
+    // With `local_bg_block_size` set, a block-median grid is built (from a
+    // staggered subsample) and everything downstream works from residuals
+    // against its bilinear surface. The residuals are produced by ONE fused
+    // pass over the image that interpolates the surface on the fly and
+    // writes the clamped measurement image and — only when the matched
+    // filter is on — the unclamped filter input directly into the blur's
+    // matrix. (Blurring the clamped image would rectify negative noise into
+    // a positive DC offset; measuring on the unclamped one would let
+    // negative pixels cancel star flux.) The materialized full-image
+    // background buffer and its separate subtract passes are gone.
+    //
+    // Noise statistics use the same estimator either way; on the local-bg
+    // path it runs on bilinear residuals at the block subsample lattice
+    // (identical reference surface, ~stride² fewer samples) instead of a
+    // full-image residual buffer.
     let gray: Cow<[f32]>;
-    let local_bg: Option<Vec<f32>>;
+    let bg_mean: f32;
+    let bg_sigma: f32;
+    let local_bg: bool;
+    let mut filter_input: Option<DynMatrix<f32>> = None;
+
     if let Some(block_size) = config.local_bg_block_size {
-        let bg = estimate_local_background(gray_input, width, height, block_size);
-        gray = Cow::Owned(par::map_subtract_clamp(gray_input, &bg));
-        local_bg = Some(bg);
+        local_bg = true;
+        let (grid, nx, ny) = background_grid(gray_input, width, height, block_size);
+        let bs = block_size as usize;
+
+        let residuals = subsample_residuals(gray_input, w, h, &grid, nx, ny, bs);
+        (bg_mean, bg_sigma) = estimate_background(&residuals, width, height, config);
+
+        // Fused residual pass (rows in parallel under the `parallel` feature;
+        // each row writes disjoint output, results independent of threads).
+        let mut clamped = vec![0.0_f32; w * h];
+        if filter_sigma.is_some() {
+            let mut unclamped = vec![0.0_f32; w * h];
+            par::for_each_chunk_pair_mut(&mut clamped, &mut unclamped, w, |y, cr, ur| {
+                let (by0, by1, fy) = interp_row_params(y, bs, ny);
+                let row = y * w;
+                for x in 0..w {
+                    let r = gray_input[row + x] - interp_bg(&grid, nx, bs, x, by0, by1, fy);
+                    cr[x] = r.max(0.0);
+                    ur[x] = r;
+                }
+            });
+            filter_input = Some(DynMatrix::from_vec(w, h, unclamped));
+        } else {
+            par::for_each_chunk_mut(&mut clamped, w, |y, cr| {
+                let (by0, by1, fy) = interp_row_params(y, bs, ny);
+                let row = y * w;
+                for (x, out) in cr.iter_mut().enumerate() {
+                    *out =
+                        (gray_input[row + x] - interp_bg(&grid, nx, bs, x, by0, by1, fy)).max(0.0);
+                }
+            });
+        }
+        gray = Cow::Owned(clamped);
     } else {
+        local_bg = false;
+        (bg_mean, bg_sigma) = estimate_background(gray_input, width, height, config);
         gray = Cow::Borrowed(gray_input);
-        local_bg = None;
+        if filter_sigma.is_some() {
+            filter_input = Some(DynMatrix::from_vec(w, h, gray_input.to_vec()));
+        }
     }
     let gray: &[f32] = &gray;
 
-    // ── Step 2: estimate residual background noise ──
-    // Use unclamped residuals for noise estimation so the lower half of the
-    // distribution is preserved (clamping to 0 destroys it).
-    let noise_input: Cow<[f32]> = if let Some(ref bg) = local_bg {
-        Cow::Owned(par::map_subtract(gray_input, bg))
-    } else {
-        Cow::Borrowed(gray_input)
-    };
-    let (bg_mean, bg_sigma) = estimate_background(&noise_input, width, height, config);
-
     // ── Step 3: optional matched filter for thresholding only ──
-    // When `matched_filter_sigma` is set, the *unclamped* residual is
-    // convolved with a Gaussian and threshold/CCL run on the filtered copy —
-    // blurring the clamped image would rectify negative noise into a
-    // positive DC offset that silently loosens the threshold. Centroids are
-    // still measured on the unfiltered `gray`, so intensities and CoM
-    // positions are unaffected. The detection threshold is scaled by the
-    // kernel's white-noise suppression factor so `sigma_threshold` keeps
-    // meaning "sigmas of the noise actually present in the thresholded
-    // image", filter on or off. Under the `parallel` feature numeris's
-    // gaussian_blur runs multi-threaded.
-    let (thresh_src, mask_threshold): (Cow<[f32]>, f32) = match config.matched_filter_sigma {
-        Some(sigma) if sigma.is_finite() && sigma > 0.0 => {
-            let mat = DynMatrix::<f32>::from_vec(w, h, noise_input.to_vec());
+    // The unclamped residual is convolved with a Gaussian and threshold/CCL
+    // run on the filtered copy; centroids are still measured on the
+    // unfiltered `gray`, so intensities and CoM positions are unaffected.
+    // The detection threshold is scaled by the kernel's white-noise
+    // suppression factor so `sigma_threshold` keeps meaning "sigmas of the
+    // noise actually present in the thresholded image", filter on or off.
+    // Under the `parallel` feature numeris's gaussian_blur runs
+    // multi-threaded.
+    let (thresh_src, mask_threshold): (Cow<[f32]>, f32) = match (filter_sigma, filter_input) {
+        (Some(sigma), Some(mat)) => {
             let filtered = gaussian_blur(&mat, sigma, BorderMode::Replicate).into_vec();
             let suppression = gaussian_noise_suppression(sigma);
             (
@@ -214,7 +253,7 @@ pub(super) fn extract_from_gray(
     // ── Step 4: compute centroids ──
     // Use the local-background-subtracted image for centroid weighting so that
     // the intensity weights reflect only the stellar signal, not the gradient.
-    let bg_for_centroids = if local_bg.is_some() {
+    let bg_for_centroids = if local_bg {
         // Already subtracted — use 0 as the level
         0.0
     } else {
@@ -265,22 +304,23 @@ pub(super) fn extract_from_gray(
     })
 }
 
-/// Estimate a spatially varying background by computing block medians and
-/// interpolating between block centers.
+/// Block-median background grid: the image is divided into
+/// `block_size × block_size` tiles and each tile's (subsampled) median is
+/// computed. Bilinear interpolation between tile centers — done on the fly by
+/// [`interp_row_params`] + the fused residual pass in [`extract_from_gray`] —
+/// reconstructs a smooth background surface that removes large-scale
+/// structure (nebulosity, Milky Way emission, vignetting) while preserving
+/// point sources. Returns `(medians, nx, ny)`, row-major `nx`-wide.
 ///
-/// The image is divided into `block_size × block_size` tiles. For each tile,
-/// the median pixel value is computed (ignoring zeros). A smooth background
-/// surface is then reconstructed via bilinear interpolation between tile
-/// centers.
-///
-/// This effectively removes large-scale structure (nebulosity, Milky Way
-/// emission, vignetting) while preserving point sources (stars).
-///
-/// This is the dominant extraction stage (~60% of wall-clock); under the
-/// `parallel` feature the per-block medians and the per-row interpolation both
-/// fan out across threads. Each block / row writes its own output slot, so the
-/// result is identical to the sequential path.
-fn estimate_local_background(pixels: &[f32], width: u32, height: u32, block_size: u32) -> Vec<f32> {
+/// Under the `parallel` feature the per-block medians fan out across threads;
+/// each block writes its own output slot, so the result is identical to the
+/// sequential path.
+fn background_grid(
+    pixels: &[f32],
+    width: u32,
+    height: u32,
+    block_size: u32,
+) -> (Vec<f32>, usize, usize) {
     let w = width as usize;
     let h = height as usize;
     let bs = block_size as usize;
@@ -341,39 +381,74 @@ fn estimate_local_background(pixels: &[f32], width: u32, height: u32, block_size
         midpoint_f32(&mut vals)
     });
 
-    // Bilinearly interpolate between block centers to produce a smooth
-    // background estimate at every pixel. Each row depends only on the shared,
-    // immutable block medians, so rows are filled in parallel over disjoint
-    // output slices.
-    let mut background = vec![0.0f32; w * h];
+    (block_medians, nx, ny)
+}
+
+/// Row-constant part of the bilinear interpolation over a block grid: for
+/// image row `y`, the two grid rows it blends between and the blend weight.
+#[inline]
+fn interp_row_params(y: usize, bs: usize, ny: usize) -> (usize, usize, f32) {
     let half_bs = bs as f32 / 2.0;
+    let by_f = (y as f32 - half_bs) / bs as f32;
+    let by0 = (by_f.floor() as isize).max(0).min(ny as isize - 1) as usize;
+    let by1 = (by0 + 1).min(ny - 1);
+    let fy = (by_f - by0 as f32).clamp(0.0, 1.0);
+    (by0, by1, fy)
+}
 
-    par::for_each_chunk_mut(&mut background, w, |y, row| {
-        // Position in block-center coordinates (row component)
-        let by_f = (y as f32 - half_bs) / bs as f32;
-        let by0 = (by_f.floor() as isize).max(0).min(ny as isize - 1) as usize;
-        let by1 = (by0 + 1).min(ny - 1);
-        let fy = (by_f - by0 as f32).clamp(0.0, 1.0);
+/// Bilinear background value at `(x, y)` from a block-median grid — the same
+/// four-term blend the materialized background buffer used to hold, evaluated
+/// on the fly. `(by0, by1, fy)` come from [`interp_row_params`].
+#[inline]
+#[allow(clippy::too_many_arguments)]
+fn interp_bg(grid: &[f32], nx: usize, bs: usize, x: usize, by0: usize, by1: usize, fy: f32) -> f32 {
+    let half_bs = bs as f32 / 2.0;
+    let bx_f = (x as f32 - half_bs) / bs as f32;
+    let bx0 = (bx_f.floor() as isize).max(0).min(nx as isize - 1) as usize;
+    let bx1 = (bx0 + 1).min(nx - 1);
+    let fx = (bx_f - bx0 as f32).clamp(0.0, 1.0);
 
-        for (x, px) in row.iter_mut().enumerate() {
-            let bx_f = (x as f32 - half_bs) / bs as f32;
-            let bx0 = (bx_f.floor() as isize).max(0).min(nx as isize - 1) as usize;
-            let bx1 = (bx0 + 1).min(nx - 1);
-            let fx = (bx_f - bx0 as f32).clamp(0.0, 1.0);
+    let m00 = grid[by0 * nx + bx0];
+    let m10 = grid[by0 * nx + bx1];
+    let m01 = grid[by1 * nx + bx0];
+    let m11 = grid[by1 * nx + bx1];
 
-            let m00 = block_medians[by0 * nx + bx0];
-            let m10 = block_medians[by0 * nx + bx1];
-            let m01 = block_medians[by1 * nx + bx0];
-            let m11 = block_medians[by1 * nx + bx1];
+    m00 * (1.0 - fx) * (1.0 - fy) + m10 * fx * (1.0 - fy) + m01 * (1.0 - fx) * fy + m11 * fx * fy
+}
 
-            *px = m00 * (1.0 - fx) * (1.0 - fy)
-                + m10 * fx * (1.0 - fy)
-                + m01 * (1.0 - fx) * fy
-                + m11 * fx * fy;
+/// Background-subtracted residuals at the block subsample lattice (the same
+/// staggered lattice [`background_grid`] medians over), against the bilinear
+/// surface — the identical reference the full-image residual pass used, so
+/// feeding these to [`estimate_background`] preserves its semantics while
+/// touching ~stride² fewer samples.
+fn subsample_residuals(
+    pixels: &[f32],
+    w: usize,
+    h: usize,
+    grid: &[f32],
+    nx: usize,
+    ny: usize,
+    bs: usize,
+) -> Vec<f32> {
+    let stride = (bs / 16).max(1);
+    let mut out: Vec<f32> = Vec::with_capacity((w / stride + 1) * (h / stride + 1));
+    let mut y = 0usize;
+    let mut phase = 0usize;
+    while y < h {
+        let (by0, by1, fy) = interp_row_params(y, bs, ny);
+        let row = y * w;
+        let mut x = phase;
+        while x < w {
+            let v = pixels[row + x];
+            if v.is_finite() {
+                out.push(v - interp_bg(grid, nx, bs, x, by0, by1, fy));
+            }
+            x += stride;
         }
-    });
-
-    background
+        phase = (phase + 1) % stride;
+        y += stride;
+    }
+    out
 }
 
 /// White-noise standard-deviation suppression factor of the separable 2-D

--- a/src/centroid_extraction/ccl.rs
+++ b/src/centroid_extraction/ccl.rs
@@ -12,7 +12,7 @@ use numeris::imageproc::{
 use numeris::DynMatrix;
 
 use super::{
-    accepted_peak_refine, median_f32, midpoint_f32, sort_and_truncate_by_mass,
+    accepted_peak_refine, median_f32, midpoint_f32, peak_sharpness, sort_and_truncate_by_mass,
     CentroidExtractionConfig, CentroidExtractionResult,
 };
 use crate::centroid::Centroid;
@@ -586,10 +586,6 @@ fn compute_blob_centroids(
             let cyy = sum_yy / sum_i - dy_bar * dy_bar;
             let cxy = sum_xy / sum_i - dx_bar * dy_bar;
 
-            // --- Quadratic peak refinement (shared gate; see accepted_peak_refine) ---
-            let mut final_x = xbar;
-            let mut final_y = ybar;
-
             let (pc, pr) = (peak_col, peak_row);
             // 3x3 grid of background-subtracted values around the peak
             let v = |dy: isize, dx: isize| -> f64 {
@@ -597,11 +593,30 @@ fn compute_blob_centroids(
                 let c = (pc as isize + dx) as usize;
                 gray[r * w + c] as f64 - local_bg
             };
-            if let Some((qx, qy)) =
-                accepted_peak_refine(pixel_count, (pc, pr), (w, h), (xbar, ybar), v)
-            {
-                final_x = qx;
-                final_y = qy;
+
+            // --- Hot-pixel / cosmic-ray sharpness gate ---
+            if let Some(max_sharp) = config.max_sharpness {
+                if let Some(s) = peak_sharpness((pc, pr), (w, h), v) {
+                    if s > max_sharp as f64 {
+                        return None;
+                    }
+                }
+            }
+
+            // --- Quadratic peak refinement (shared gate; see accepted_peak_refine) ---
+            // Skipped when the peak is saturated: a flat-topped or bloomed
+            // profile has no meaningful sub-pixel maximum, and a 2-3 px flat
+            // top can still "pass" the parabola with a skewed vertex.
+            let mut final_x = xbar;
+            let mut final_y = ybar;
+            let saturated = config.saturation_level.is_some_and(|s| peak_val >= s);
+            if !saturated {
+                if let Some((qx, qy)) =
+                    accepted_peak_refine(pixel_count, (pc, pr), (w, h), (xbar, ybar), v)
+                {
+                    final_x = qx;
+                    final_y = qy;
+                }
             }
 
             Some(RawCentroid {

--- a/src/centroid_extraction/ccl.rs
+++ b/src/centroid_extraction/ccl.rs
@@ -341,9 +341,9 @@ fn estimate_local_background(pixels: &[f32], width: u32, height: u32, block_size
 /// lower half of the pixel distribution (below the median). This is robust
 /// to contamination from stars and nebulosity, which only bias upward.
 ///
-/// The noise estimate uses sigma-clipping on the below-median pixels to
-/// further reject any remaining outliers, then mirrors the lower-half RMS
-/// to get the full Gaussian sigma.
+/// The noise estimate sigma-clips the below-median tail to reject remaining
+/// outliers, then mirrors the lower-half RMS **about the median** to get the
+/// full Gaussian sigma (`E[(v−m)² | v ≤ m] = σ²`).
 pub(super) fn estimate_background(
     gray: &[f32],
     _width: u32,
@@ -358,30 +358,34 @@ pub(super) fn estimate_background(
     // Median as robust background level (O(n) selection; see `median_f32`).
     let median = median_f32(&mut values);
 
-    // Estimate noise from pixels at or below the median (uncontaminated by stars).
-    // These represent the "dark side" of the noise distribution.
+    // Estimate noise from pixels at or below the median (uncontaminated by
+    // stars, which only push the distribution upward). For Gaussian noise the
+    // second moment of the lower half about the *median* equals the full
+    // variance — E[(v−m)² | v ≤ m] = σ² — so the lower-half RMS about the
+    // median mirrors directly into the full Gaussian sigma. This matches the
+    // fast path's `coarse_background`. (Historically this computed the RMS
+    // about the lower half's own mean, which for a half-normal is only
+    // ≈0.60σ — silently turning a nominal 5σ threshold into a ~3σ one.)
     let mut low_half: Vec<f32> = values.iter().copied().filter(|&v| v <= median).collect();
 
-    // Sigma-clip the lower half to reject any remaining outliers
+    // Sigma-clip the lower tail to reject remaining outliers (dead or
+    // negative pixels), re-estimating about the median each pass.
     let mut sigma = 0.0_f32;
     for _ in 0..config.sigma_clip_iterations {
         if low_half.is_empty() {
             break;
         }
-        let sum: f64 = low_half.iter().map(|&v| v as f64).sum();
-        let mean_low = (sum / low_half.len() as f64) as f32;
         let var_sum: f64 = low_half
             .iter()
-            .map(|&v| ((v - mean_low) as f64).powi(2))
+            .map(|&v| ((v - median) as f64).powi(2))
             .sum();
         sigma = (var_sum / low_half.len() as f64).sqrt() as f32;
         if sigma < 1e-10 {
             break;
         }
-        let lo = mean_low - config.sigma_clip_factor * sigma;
-        let hi = mean_low + config.sigma_clip_factor * sigma;
+        let lo = median - config.sigma_clip_factor * sigma;
         let before = low_half.len();
-        low_half.retain(|&v| v >= lo && v <= hi);
+        low_half.retain(|&v| v >= lo);
         if low_half.len() == before {
             break; // converged
         }

--- a/src/centroid_extraction/fast.rs
+++ b/src/centroid_extraction/fast.rs
@@ -4,8 +4,8 @@
 //! [`extract_centroids_fast`].
 
 use super::{
-    accepted_peak_refine, check_pixel_len, midpoint_f32, peak_sharpness, sort_and_truncate_by_mass,
-    CentroidExtractionResult,
+    accepted_peak_refine, check_pixel_len, elongation_from_cov, midpoint_f32, peak_sharpness,
+    sort_and_truncate_by_mass, CentroidExtractionResult,
 };
 use crate::centroid::Centroid;
 use crate::error::{Error, Result};
@@ -57,6 +57,22 @@ pub struct FastCentroidConfig {
     /// maximum), keeping the center-of-mass position.
     /// Default: None (disabled)
     pub saturation_level: Option<f32>,
+
+    /// Maximum pixels in a region. Results are brightest-first, so without a
+    /// cap a satellite trail, aircraft streak, or horizon glow becomes the
+    /// *top* centroid handed to the solver. Real stars never approach the
+    /// default; only raise it for deliberately defocused optics.
+    /// Default: 10000
+    pub max_pixels: usize,
+
+    /// Maximum elongation ratio (major/minor axis from intensity-weighted
+    /// second moments) — rejects streaks and trails too small for
+    /// `max_pixels`. Off by default: moment-based elongation is noisy for
+    /// regions of only a few pixels (this path's `min_pixels` default is 2),
+    /// so enable it (e.g. 3.0-5.0) when trails are expected and `min_pixels`
+    /// is raised enough (≳5) for the moments to be meaningful.
+    /// Default: None (disabled)
+    pub max_elongation: Option<f32>,
 }
 
 impl Default for FastCentroidConfig {
@@ -68,6 +84,8 @@ impl Default for FastCentroidConfig {
             max_centroids: None,
             max_sharpness: Some(0.9),
             saturation_level: None,
+            max_pixels: 10000,
+            max_elongation: None,
         }
     }
 }
@@ -77,9 +95,12 @@ impl Default for FastCentroidConfig {
 #[derive(Clone, Copy)]
 struct Region {
     parent: u32,
-    sum_w: f64,  // Σ (value − bg), the background-subtracted flux
-    sum_wx: f64, // Σ x·(value − bg)
-    sum_wy: f64, // Σ y·(value − bg)
+    sum_w: f64,   // Σ (value − bg), the background-subtracted flux
+    sum_wx: f64,  // Σ x·(value − bg)
+    sum_wy: f64,  // Σ y·(value − bg)
+    sum_wxx: f64, // Σ x²·(value − bg)
+    sum_wyy: f64, // Σ y²·(value − bg)
+    sum_wxy: f64, // Σ x·y·(value − bg)
     npix: u32,
     peak_val: f32,
     peak_x: u32,
@@ -170,6 +191,9 @@ pub fn extract_centroids_fast(
                             sum_w: 0.0,
                             sum_wx: 0.0,
                             sum_wy: 0.0,
+                            sum_wxx: 0.0,
+                            sum_wyy: 0.0,
+                            sum_wxy: 0.0,
                             npix: 0,
                             peak_val: f32::NEG_INFINITY,
                             peak_x: c as u32,
@@ -178,9 +202,13 @@ pub fn extract_centroids_fast(
                     ));
                 }
                 let reg = &mut active.as_mut().unwrap().1;
+                let (cf, rf) = (c as f64, r as f64);
                 reg.sum_w += weight;
-                reg.sum_wx += weight * c as f64;
-                reg.sum_wy += weight * r as f64;
+                reg.sum_wx += weight * cf;
+                reg.sum_wy += weight * rf;
+                reg.sum_wxx += weight * cf * cf;
+                reg.sum_wyy += weight * rf * rf;
+                reg.sum_wxy += weight * cf * rf;
                 reg.npix += 1;
                 if p > reg.peak_val {
                     reg.peak_val = p;
@@ -229,17 +257,16 @@ pub fn extract_centroids_fast(
     for lab in 0..n_labels {
         let root = find(&mut regions, lab as u32) as usize;
         if root != lab {
-            let (sw, swx, swy, np, pv, px, py) = {
-                let c = &regions[lab];
-                (
-                    c.sum_w, c.sum_wx, c.sum_wy, c.npix, c.peak_val, c.peak_x, c.peak_y,
-                )
-            };
+            let child = regions[lab];
             let rt = &mut regions[root];
-            rt.sum_w += sw;
-            rt.sum_wx += swx;
-            rt.sum_wy += swy;
-            rt.npix += np;
+            rt.sum_w += child.sum_w;
+            rt.sum_wx += child.sum_wx;
+            rt.sum_wy += child.sum_wy;
+            rt.sum_wxx += child.sum_wxx;
+            rt.sum_wyy += child.sum_wyy;
+            rt.sum_wxy += child.sum_wxy;
+            rt.npix += child.npix;
+            let (pv, px, py) = (child.peak_val, child.peak_x, child.peak_y);
             if pv > rt.peak_val {
                 rt.peak_val = pv;
                 rt.peak_x = px;
@@ -260,11 +287,25 @@ pub fn extract_centroids_fast(
         }
         num_blobs_raw += 1;
         let reg = regions[lab];
-        if (reg.npix as usize) < config.min_pixels || reg.sum_w <= 0.0 {
+        if (reg.npix as usize) < config.min_pixels
+            || (reg.npix as usize) > config.max_pixels
+            || reg.sum_w <= 0.0
+        {
             continue;
         }
         let mut fx = reg.sum_wx / reg.sum_w;
         let mut fy = reg.sum_wy / reg.sum_w;
+
+        // Intensity-weighted central second moments — the same statistic the
+        // CCL path reports as `cov` and judges elongation on.
+        let cxx = reg.sum_wxx / reg.sum_w - fx * fx;
+        let cyy = reg.sum_wyy / reg.sum_w - fy * fy;
+        let cxy = reg.sum_wxy / reg.sum_w - fx * fy;
+        if let Some(max_elong) = config.max_elongation {
+            if elongation_from_cov(cxx, cyy, cxy) > max_elong {
+                continue;
+            }
+        }
 
         let (pc, pr) = (reg.peak_x as usize, reg.peak_y as usize);
         let bg = bilinear_grid(&bg_grid, nx, ny, block, pc, pr) as f64;
@@ -300,7 +341,10 @@ pub fn extract_centroids_fast(
             x: fx as f32 - cx,
             y: fy as f32 - cy,
             mass: Some(reg.sum_w as f32),
-            cov: None,
+            cov: Some(crate::Matrix2::new([
+                [cxx as f32, cxy as f32],
+                [cxy as f32, cyy as f32],
+            ])),
         });
     }
 

--- a/src/centroid_extraction/fast.rs
+++ b/src/centroid_extraction/fast.rs
@@ -169,13 +169,32 @@ pub fn extract_centroids_fast(
     let mut prev: Vec<(u32, u32, u32)> = Vec::new();
     let mut cur: Vec<(u32, u32, u32)> = Vec::new();
 
+    // Row-blended copy of the background grid, rebuilt at each row: the
+    // y-half of the bilinear interpolation is row-constant, so hoisting it
+    // leaves only a 1-D lerp per pixel in the sweep (the dominant cost).
+    // Same blend up to f32 associativity as `bilinear_grid`.
+    let mut grid_row = vec![0.0_f32; nx];
+    let half = block as f32 / 2.0;
+
     for r in 0..h {
         cur.clear();
         let row = r * w;
         let mut active: Option<(u32, Region)> = None; // (start_col, accumulator)
 
+        let fyf = (r as f32 - half) / block as f32;
+        let by0 = (fyf.floor() as isize).clamp(0, ny as isize - 1) as usize;
+        let by1 = (by0 + 1).min(ny - 1);
+        let fy = (fyf - by0 as f32).clamp(0.0, 1.0);
+        for (bx, g) in grid_row.iter_mut().enumerate() {
+            *g = bg_grid[by0 * nx + bx] * (1.0 - fy) + bg_grid[by1 * nx + bx] * fy;
+        }
+
         for c in 0..w {
-            let bg = bilinear_grid(&bg_grid, nx, ny, block, c, r);
+            let fxf = (c as f32 - half) / block as f32;
+            let bx0 = (fxf.floor() as isize).clamp(0, nx as isize - 1) as usize;
+            let bx1 = (bx0 + 1).min(nx - 1);
+            let fx = (fxf - bx0 as f32).clamp(0.0, 1.0);
+            let bg = grid_row[bx0] * (1.0 - fx) + grid_row[bx1] * fx;
             let p = pixels[row + c];
             let lit = p.is_finite() && p > bg + k * sigma;
 

--- a/src/centroid_extraction/fast.rs
+++ b/src/centroid_extraction/fast.rs
@@ -4,7 +4,7 @@
 //! [`extract_centroids_fast`].
 
 use super::{
-    accepted_peak_refine, check_pixel_len, midpoint_f32, sort_and_truncate_by_mass,
+    accepted_peak_refine, check_pixel_len, midpoint_f32, peak_sharpness, sort_and_truncate_by_mass,
     CentroidExtractionResult,
 };
 use crate::centroid::Centroid;
@@ -40,6 +40,23 @@ pub struct FastCentroidConfig {
     /// all detections. For plate solving / tracking a few dozen is plenty.
     /// Default: None
     pub max_centroids: Option<usize>,
+
+    /// Maximum DAOFIND-style sharpness: `(peak − mean(8 neighbors)) / peak`,
+    /// measured on the background-subtracted image at the region's peak.
+    /// Values near 1 mean single-pixel flux — a hot pixel or cosmic-ray hit.
+    /// A critically sampled PSF scores ~0.5; a strongly undersampled one up
+    /// to ~0.85 — and at very coarse plate scales (sub-pixel PSF) real stars
+    /// are indistinguishable from hot pixels, so the gate must stay off.
+    /// Enable (~0.7-0.9) only when the PSF spans multiple pixels.
+    /// Default: None (disabled)
+    pub max_sharpness: Option<f32>,
+
+    /// Pixel value at or above which the sensor is considered saturated.
+    /// A region whose peak reaches this level skips the 3×3 parabola
+    /// refinement (a flat-topped profile has no meaningful sub-pixel
+    /// maximum), keeping the center-of-mass position.
+    /// Default: None (disabled)
+    pub saturation_level: Option<f32>,
 }
 
 impl Default for FastCentroidConfig {
@@ -49,6 +66,8 @@ impl Default for FastCentroidConfig {
             bg_grid: 64,
             min_pixels: 2,
             max_centroids: None,
+            max_sharpness: None,
+            saturation_level: None,
         }
     }
 }
@@ -247,8 +266,6 @@ pub fn extract_centroids_fast(
         let mut fx = reg.sum_wx / reg.sum_w;
         let mut fy = reg.sum_wy / reg.sum_w;
 
-        // Optional 3×3 parabola refine on the raw image at the peak (shared
-        // gate with the CCL path — see `accepted_peak_refine`).
         let (pc, pr) = (reg.peak_x as usize, reg.peak_y as usize);
         let bg = bilinear_grid(&bg_grid, nx, ny, block, pc, pr) as f64;
         let v = |dy: isize, dx: isize| -> f64 {
@@ -256,11 +273,27 @@ pub fn extract_centroids_fast(
             let cc = (pc as isize + dx) as usize;
             pixels[rr * w + cc] as f64 - bg
         };
-        if let Some((qx, qy)) =
-            accepted_peak_refine(reg.npix as usize, (pc, pr), (w, h), (fx, fy), v)
-        {
-            fx = qx;
-            fy = qy;
+
+        // Hot-pixel / cosmic-ray sharpness gate (shared with the CCL path).
+        if let Some(max_sharp) = config.max_sharpness {
+            if let Some(s) = peak_sharpness((pc, pr), (w, h), v) {
+                if s > max_sharp as f64 {
+                    continue;
+                }
+            }
+        }
+
+        // Optional 3×3 parabola refine on the raw image at the peak (shared
+        // gate with the CCL path — see `accepted_peak_refine`). Skipped for
+        // saturated peaks (no meaningful sub-pixel maximum on a flat top).
+        let saturated = config.saturation_level.is_some_and(|s| reg.peak_val >= s);
+        if !saturated {
+            if let Some((qx, qy)) =
+                accepted_peak_refine(reg.npix as usize, (pc, pr), (w, h), (fx, fy), v)
+            {
+                fx = qx;
+                fy = qy;
+            }
         }
 
         centroids.push(Centroid {

--- a/src/centroid_extraction/fast.rs
+++ b/src/centroid_extraction/fast.rs
@@ -45,10 +45,10 @@ pub struct FastCentroidConfig {
     /// measured on the background-subtracted image at the region's peak.
     /// Values near 1 mean single-pixel flux — a hot pixel or cosmic-ray hit.
     /// A critically sampled PSF scores ~0.5; a strongly undersampled one up
-    /// to ~0.85 — and at very coarse plate scales (sub-pixel PSF) real stars
-    /// are indistinguishable from hot pixels, so the gate must stay off.
-    /// Enable (~0.7-0.9) only when the PSF spans multiple pixels.
-    /// Default: None (disabled)
+    /// to ~0.85. The default 0.9 passes any system whose PSF spans multiple
+    /// pixels; set `None` for severely undersampled data (PSF FWHM below
+    /// ~1.5 px), where real stars are indistinguishable from hot pixels.
+    /// Default: Some(0.9)
     pub max_sharpness: Option<f32>,
 
     /// Pixel value at or above which the sensor is considered saturated.
@@ -66,7 +66,7 @@ impl Default for FastCentroidConfig {
             bg_grid: 64,
             min_pixels: 2,
             max_centroids: None,
-            max_sharpness: None,
+            max_sharpness: Some(0.9),
             saturation_level: None,
         }
     }

--- a/src/centroid_extraction/mod.rs
+++ b/src/centroid_extraction/mod.rs
@@ -121,16 +121,20 @@ pub struct CentroidExtractionConfig {
     /// centroid positions and intensities are still measured on the
     /// unfiltered bg-subtracted image, so photometry is unaffected.
     ///
-    /// A matched filter boosts point-source SNR by concentrating the
-    /// star's PSF into fewer effective pixels before thresholding. The
-    /// gain is largest for faint stars in noisy or dense images. The
-    /// filter has a broad optimum: σ within a factor of ~2 of the true
-    /// PSF width still recovers nearly all the SNR.
+    /// A matched filter boosts point-source SNR before thresholding —
+    /// ~2× peak SNR (≈0.75 mag more depth at the same false-positive rate)
+    /// for a σ≈1.5 px PSF. The gain is largest for faint stars in noisy or
+    /// dense images, and the optimum is broad: σ within a factor of ~2 of
+    /// the true PSF width recovers nearly all of it.
     ///
-    /// When enabled, consider lowering `sigma_threshold` (e.g. to 2.5–3.0)
-    /// since the filtered image has lower noise.
+    /// The detection threshold is automatically scaled by the kernel's
+    /// noise-suppression factor, so `sigma_threshold` means "sigmas of the
+    /// noise actually present in the thresholded image" whether the filter
+    /// is on or off — no retuning needed when toggling it.
     ///
-    /// Default: None (disabled).
+    /// Default: Some(1.5). Set `None` to threshold the unfiltered image
+    /// (marginally faster; appropriate when downstream limits like
+    /// `max_centroids` make faint-star depth irrelevant).
     pub matched_filter_sigma: Option<f32>,
 
     /// Maximum DAOFIND-style sharpness: `(peak − mean(8 neighbors)) / peak`,
@@ -168,7 +172,7 @@ impl Default for CentroidExtractionConfig {
             use_8_connectivity: true,
             local_bg_block_size: Some(64),
             max_elongation: Some(3.0),
-            matched_filter_sigma: None,
+            matched_filter_sigma: Some(1.5),
             max_sharpness: Some(0.9),
             saturation_level: None,
         }
@@ -514,6 +518,62 @@ mod tests {
         assert!(c.x.abs() < 1.0, "Expected x near 0, got {}", c.x);
         assert!(c.y.abs() < 1.0, "Expected y near 0, got {}", c.y);
         assert!(c.mass.unwrap() > 0.0);
+    }
+
+    #[test]
+    fn test_matched_filter_depth_gain() {
+        // A star too faint for the unfiltered 5σ cut is recovered when the
+        // matched filter is on — at the SAME sigma_threshold, because the
+        // detection threshold is scaled by the kernel's noise-suppression
+        // factor automatically.
+        let (width, height) = (64u32, 64u32);
+        let pixels = render_stars(width, height, 100.0, 0.0, 20.0, 1.5, &[(30.0, 30.0, 20.0)]);
+        let base = CentroidExtractionConfig {
+            sigma_threshold: 5.0,
+            local_bg_block_size: None,
+            matched_filter_sigma: None,
+            ..Default::default()
+        };
+        let unfiltered = extract_centroids_from_raw(&pixels, width, height, &base).unwrap();
+        assert_eq!(
+            unfiltered.centroids.len(),
+            0,
+            "star should sit below the unfiltered cut"
+        );
+
+        let filtered_cfg = CentroidExtractionConfig {
+            matched_filter_sigma: Some(1.5),
+            ..base
+        };
+        let filtered = extract_centroids_from_raw(&pixels, width, height, &filtered_cfg).unwrap();
+        assert_eq!(
+            filtered.centroids.len(),
+            1,
+            "matched filter should recover the faint star"
+        );
+        assert!((filtered.centroids[0].x - (30.0 - 31.5)).abs() < 1.0);
+        assert!((filtered.centroids[0].y - (30.0 - 31.5)).abs() < 1.0);
+    }
+
+    #[test]
+    fn test_matched_filter_no_noise_false_positives() {
+        // Pure noise + gradient with the (default-on) filter and local
+        // background: the compensated threshold must keep false positives at
+        // zero. Regression guard: convolving the *clamped* residual rectified
+        // negative noise into a positive DC offset comparable to the
+        // compensated threshold, which would light up the whole frame.
+        let (width, height) = (128u32, 128u32);
+        let pixels = render_stars(width, height, 100.0, 30.0, 20.0, 1.5, &[]);
+        let cfg = CentroidExtractionConfig {
+            sigma_threshold: 5.0,
+            ..Default::default()
+        };
+        let res = extract_centroids_from_raw(&pixels, width, height, &cfg).unwrap();
+        assert_eq!(
+            res.centroids.len(),
+            0,
+            "noise-only frame produced detections"
+        );
     }
 
     #[test]

--- a/src/centroid_extraction/mod.rs
+++ b/src/centroid_extraction/mod.rs
@@ -132,6 +132,27 @@ pub struct CentroidExtractionConfig {
     ///
     /// Default: None (disabled).
     pub matched_filter_sigma: Option<f32>,
+
+    /// Maximum DAOFIND-style sharpness: `(peak − mean(8 neighbors)) / peak`,
+    /// measured on the background-subtracted image at the blob's peak. Values
+    /// near 1 mean the flux is concentrated in a single pixel — a hot pixel
+    /// or cosmic-ray hit rather than a star. A critically sampled PSF scores
+    /// ~0.5; a strongly undersampled one can reach ~0.85; at very coarse
+    /// plate scales (PSF FWHM below a pixel, e.g. a 10° FOV on a 2k sensor)
+    /// real stars are single-pixel and indistinguishable from hot pixels, so
+    /// the gate must stay off. Enable (~0.7-0.9) only when the PSF spans
+    /// multiple pixels.
+    ///
+    /// Default: None (disabled)
+    pub max_sharpness: Option<f32>,
+
+    /// Pixel value at or above which the sensor is considered saturated.
+    /// A blob whose peak reaches this level skips quadratic peak refinement
+    /// (a flat-topped or bloomed profile has no meaningful sub-pixel
+    /// maximum), keeping the center-of-mass position instead.
+    ///
+    /// Default: None (disabled)
+    pub saturation_level: Option<f32>,
 }
 
 impl Default for CentroidExtractionConfig {
@@ -147,6 +168,8 @@ impl Default for CentroidExtractionConfig {
             local_bg_block_size: Some(64),
             max_elongation: Some(3.0),
             matched_filter_sigma: None,
+            max_sharpness: None,
+            saturation_level: None,
         }
     }
 }
@@ -304,6 +327,45 @@ fn accepted_peak_refine(
     }
 }
 
+/// DAOFIND-style sharpness of a blob peak: `(peak − mean(8 neighbors)) / peak`
+/// on background-subtracted values (`v(dy, dx)` samples relative to the peak,
+/// the same accessor convention as [`accepted_peak_refine`]). Out-of-bounds
+/// neighbors are skipped. Values near 1 mean the flux is concentrated in a
+/// single pixel — a hot pixel or cosmic-ray hit; a real PSF puts substantial
+/// flux into the neighbors (critically sampled ~0.5, strongly undersampled up
+/// to ~0.85). Returns `None` when the peak is non-positive or has no
+/// in-bounds neighbors (sharpness undefined — callers should not reject).
+fn peak_sharpness(
+    (pc, pr): (usize, usize),
+    (w, h): (usize, usize),
+    v: impl Fn(isize, isize) -> f64,
+) -> Option<f64> {
+    let peak = v(0, 0);
+    if peak <= 0.0 {
+        return None;
+    }
+    let mut sum = 0.0_f64;
+    let mut n = 0u32;
+    for dy in -1..=1_isize {
+        for dx in -1..=1_isize {
+            if dy == 0 && dx == 0 {
+                continue;
+            }
+            let rr = pr as isize + dy;
+            let cc = pc as isize + dx;
+            if rr < 0 || cc < 0 || rr >= h as isize || cc >= w as isize {
+                continue;
+            }
+            sum += v(dy, dx);
+            n += 1;
+        }
+    }
+    if n == 0 {
+        return None;
+    }
+    Some((peak - sum / n as f64) / peak)
+}
+
 /// Convert a DynamicImage to a Vec<f32> of grayscale values.
 fn to_grayscale_f32(img: &image::DynamicImage) -> Vec<f32> {
     use image::DynamicImage;
@@ -451,6 +513,113 @@ mod tests {
         assert!(c.x.abs() < 1.0, "Expected x near 0, got {}", c.x);
         assert!(c.y.abs() < 1.0, "Expected y near 0, got {}", c.y);
         assert!(c.mass.unwrap() > 0.0);
+    }
+
+    #[test]
+    fn test_peak_sharpness_values() {
+        // Lone hot pixel: all 8 neighbors zero → sharpness exactly 1.
+        let hot = |dy: isize, dx: isize| if dy == 0 && dx == 0 { 100.0 } else { 0.0 };
+        assert_eq!(peak_sharpness((1, 1), (3, 3), hot), Some(1.0));
+        // Flat plateau: neighbors equal the peak → sharpness 0.
+        let flat = |_: isize, _: isize| 50.0;
+        assert_eq!(peak_sharpness((1, 1), (3, 3), flat), Some(0.0));
+        // Corner peak: only the 3 in-bounds neighbors are averaged.
+        let corner = |dy: isize, dx: isize| if dy == 0 && dx == 0 { 90.0 } else { 30.0 };
+        assert_eq!(
+            peak_sharpness((0, 0), (3, 3), corner),
+            Some((90.0 - 30.0) / 90.0)
+        );
+        // Non-positive peak: undefined.
+        assert_eq!(peak_sharpness((1, 1), (3, 3), |_, _| -1.0), None);
+    }
+
+    #[test]
+    fn test_sharpness_gate_rejects_hot_pixel() {
+        // A real star plus a single hot pixel. The matched filter smears the
+        // hot pixel into a blob that passes `min_pixels`, but its sharpness
+        // on the *unfiltered* image (~1.0) trips the gate; the star (~0.5)
+        // survives. With the gate disabled, both are detected.
+        let (width, height) = (64u32, 64u32);
+        let mut pixels = render_stars(width, height, 10.0, 0.0, 2.0, 1.5, &[(20.0, 20.0, 800.0)]);
+        pixels[44 * 64 + 44] += 1200.0;
+
+        let base = CentroidExtractionConfig {
+            sigma_threshold: 4.0,
+            min_pixels: 3,
+            matched_filter_sigma: Some(1.5),
+            local_bg_block_size: None,
+            max_sharpness: Some(0.9),
+            ..Default::default()
+        };
+        let gated = extract_centroids_from_raw(&pixels, width, height, &base).unwrap();
+        assert_eq!(
+            gated.centroids.len(),
+            1,
+            "hot pixel should be rejected by the sharpness gate"
+        );
+        assert!((gated.centroids[0].x - (20.0 - 31.5)).abs() < 1.0);
+
+        let ungated = CentroidExtractionConfig {
+            max_sharpness: None,
+            ..base
+        };
+        let all = extract_centroids_from_raw(&pixels, width, height, &ungated).unwrap();
+        assert_eq!(
+            all.centroids.len(),
+            2,
+            "gate disabled: hot pixel should be detected"
+        );
+    }
+
+    #[test]
+    fn test_fast_path_sharpness_gate() {
+        // Single hot pixel with min_pixels = 1: only the sharpness gate can
+        // reject it on the fast path.
+        let (width, height) = (64u32, 64u32);
+        let mut pixels = render_stars(width, height, 10.0, 0.0, 2.0, 1.5, &[(20.0, 20.0, 800.0)]);
+        pixels[44 * 64 + 44] += 1200.0;
+
+        let base = FastCentroidConfig {
+            sigma_threshold: 4.0,
+            min_pixels: 1,
+            max_sharpness: Some(0.9),
+            ..Default::default()
+        };
+        let gated = extract_centroids_fast(&pixels, width, height, &base).unwrap();
+        assert_eq!(gated.centroids.len(), 1, "hot pixel should be rejected");
+
+        let ungated = FastCentroidConfig {
+            max_sharpness: None,
+            ..base
+        };
+        let all = extract_centroids_fast(&pixels, width, height, &ungated).unwrap();
+        assert_eq!(all.centroids.len(), 2, "gate disabled: hot pixel detected");
+    }
+
+    #[test]
+    fn test_saturation_guard_keeps_com() {
+        // A clipped (flat-top) star: with `saturation_level` set the parabola
+        // refinement is skipped and the CoM position is kept. The symmetric
+        // clipped PSF still centroids onto the true position.
+        let (width, height) = (64u32, 64u32);
+        let raw = render_stars(width, height, 10.0, 0.0, 1.0, 2.0, &[(30.0, 33.0, 20000.0)]);
+        let clipped: Vec<f32> = raw.iter().map(|&v| v.min(1000.0)).collect();
+
+        let config = CentroidExtractionConfig {
+            sigma_threshold: 4.0,
+            saturation_level: Some(1000.0),
+            local_bg_block_size: None,
+            ..Default::default()
+        };
+        let res = extract_centroids_from_raw(&clipped, width, height, &config).unwrap();
+        assert_eq!(res.centroids.len(), 1);
+        let c = &res.centroids[0];
+        assert!(
+            (c.x - (30.0 - 31.5)).abs() < 0.3 && (c.y - (33.0 - 31.5)).abs() < 0.3,
+            "saturated star CoM off: ({}, {})",
+            c.x,
+            c.y
+        );
     }
 
     /// Helper: render Gaussian stars on a background with an optional gradient

--- a/src/centroid_extraction/mod.rs
+++ b/src/centroid_extraction/mod.rs
@@ -562,8 +562,13 @@ mod tests {
         // zero. Regression guard: convolving the *clamped* residual rectified
         // negative noise into a positive DC offset comparable to the
         // compensated threshold, which would light up the whole frame.
-        let (width, height) = (128u32, 128u32);
-        let pixels = render_stars(width, height, 100.0, 30.0, 20.0, 1.5, &[]);
+        // 4x4+ background blocks: the bilinear background clamps at the
+        // outermost block centers, so a steep gradient on a 2-block-wide
+        // frame leaves an un-modeled ramp near the borders that exceeds any
+        // tight threshold — a (pre-existing) edge-extrapolation limitation,
+        // not what this test measures.
+        let (width, height) = (256u32, 256u32);
+        let pixels = render_stars(width, height, 100.0, 10.0, 20.0, 1.5, &[]);
         let cfg = CentroidExtractionConfig {
             sigma_threshold: 5.0,
             ..Default::default()
@@ -699,10 +704,16 @@ mod tests {
         for row in 0..h {
             for col in 0..w {
                 // Large-scale gradient the coarse-grid background must reject,
-                // plus a cheap deterministic dither so the noise σ is nonzero.
-                let dither = (((row * w + col) as u32).wrapping_mul(2_654_435_761) >> 8) as f32
-                    / 16_777_216.0
-                    - 0.5;
+                // plus deterministic hash noise (splitmix64 finalizer). A
+                // proper hash matters: the multiplicative Weyl sequence this
+                // helper once used is an arithmetic progression mod 1, whose
+                // subsequences under any strided sampling are grossly
+                // non-uniform — unlike real sensor noise.
+                let mut z = (row * w + col) as u64 ^ 0x9e37_79b9_7f4a_7c15;
+                z = (z ^ (z >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+                z = (z ^ (z >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+                z ^= z >> 31;
+                let dither = (z >> 40) as f32 / 16_777_216.0 - 0.5;
                 pixels[row * w + col] = bg + gradient * (col as f32 / w as f32) + noise * dither;
             }
         }

--- a/src/centroid_extraction/mod.rs
+++ b/src/centroid_extraction/mod.rs
@@ -137,13 +137,14 @@ pub struct CentroidExtractionConfig {
     /// measured on the background-subtracted image at the blob's peak. Values
     /// near 1 mean the flux is concentrated in a single pixel — a hot pixel
     /// or cosmic-ray hit rather than a star. A critically sampled PSF scores
-    /// ~0.5; a strongly undersampled one can reach ~0.85; at very coarse
-    /// plate scales (PSF FWHM below a pixel, e.g. a 10° FOV on a 2k sensor)
-    /// real stars are single-pixel and indistinguishable from hot pixels, so
-    /// the gate must stay off. Enable (~0.7-0.9) only when the PSF spans
-    /// multiple pixels.
+    /// ~0.5; a strongly undersampled one can reach ~0.85. The default 0.9
+    /// passes any system whose PSF spans multiple pixels (the design norm —
+    /// star trackers defocus deliberately, because a sub-pixel PSF forfeits
+    /// sub-pixel centroiding). Set `None` for severely undersampled data
+    /// (PSF FWHM below ~1.5 px), where real stars are geometrically
+    /// indistinguishable from hot pixels.
     ///
-    /// Default: None (disabled)
+    /// Default: Some(0.9)
     pub max_sharpness: Option<f32>,
 
     /// Pixel value at or above which the sensor is considered saturated.
@@ -168,7 +169,7 @@ impl Default for CentroidExtractionConfig {
             local_bg_block_size: Some(64),
             max_elongation: Some(3.0),
             matched_filter_sigma: None,
-            max_sharpness: None,
+            max_sharpness: Some(0.9),
             saturation_level: None,
         }
     }

--- a/src/centroid_extraction/mod.rs
+++ b/src/centroid_extraction/mod.rs
@@ -305,12 +305,34 @@ fn check_pixel_len(len: usize, width: u32, height: u32) -> Result<()> {
     Ok(())
 }
 
+/// Elongation ratio (major/minor axis) of a blob from its intensity-weighted
+/// central second moments: `√(λ_max/λ_min)` of the 2×2 covariance
+/// `[[cxx, cxy], [cxy, cyy]]`. `λ_min` is floored so degenerate (collinear)
+/// blobs come out very elongated rather than dividing by zero — the correct
+/// verdict for a 1-pixel-wide streak. Shared by both extraction paths.
+fn elongation_from_cov(cxx: f64, cyy: f64, cxy: f64) -> f32 {
+    let trace = cxx + cyy;
+    let det = cxx * cyy - cxy * cxy;
+    let disc = (trace * trace - 4.0 * det).max(0.0).sqrt();
+    let lambda_max = (trace + disc) / 2.0;
+    let lambda_min = (trace - disc).max(1e-12) / 2.0;
+    (lambda_max / lambda_min).sqrt() as f32
+}
+
 /// 3×3 parabola sub-pixel refinement at the integer peak `(pc, pr)`, gated the
 /// same way in both extraction paths: the blob must have ≥ 5 pixels, the peak
 /// must not touch the border of the `(w, h)` image, and the fitted position
 /// must agree with the center-of-mass estimate `(com_x, com_y)` within 0.5 px
 /// (for asymmetric or blended blobs the CoM is more reliable). Returns the
 /// refined position, or `None` to keep the CoM.
+///
+/// When all nine background-subtracted samples are positive, the parabola is
+/// fit to **log intensity**: a Gaussian PSF is exactly quadratic in
+/// `ln(v)` (`ln(A·e^{−r²/2σ²}) = ln A − r²/2σ²`), which removes most of the
+/// linear fit's S-curve bias (~0.05–0.1 px at quarter-pixel peak phases —
+/// the classic star-tracker refinement). Blobs with a non-positive sample in
+/// the window (faint stars whose wings dip below the local background) keep
+/// the linear fit, preserving the previous behavior there.
 fn accepted_peak_refine(
     npix: usize,
     (pc, pr): (usize, usize),
@@ -321,7 +343,24 @@ fn accepted_peak_refine(
     if npix < 5 || pc < 1 || pr < 1 || pc + 1 >= w || pr + 1 >= h {
         return None;
     }
-    let (x_off, y_off) = quadratic_peak_offset(v)?;
+    let mut vals = [[0.0_f64; 3]; 3];
+    let mut all_positive = true;
+    for dy in -1..=1_isize {
+        for dx in -1..=1_isize {
+            let val = v(dy, dx);
+            vals[(dy + 1) as usize][(dx + 1) as usize] = val;
+            all_positive &= val > 0.0;
+        }
+    }
+    if all_positive {
+        for row in vals.iter_mut() {
+            for val in row.iter_mut() {
+                *val = val.ln();
+            }
+        }
+    }
+    let (x_off, y_off) =
+        quadratic_peak_offset(|dy, dx| vals[(dy + 1) as usize][(dx + 1) as usize])?;
     let qx = pc as f64 + x_off;
     let qy = pr as f64 + y_off;
     let dist_sq = (qx - com_x) * (qx - com_x) + (qy - com_y) * (qy - com_y);
@@ -518,6 +557,99 @@ mod tests {
         assert!(c.x.abs() < 1.0, "Expected x near 0, got {}", c.x);
         assert!(c.y.abs() < 1.0, "Expected y near 0, got {}", c.y);
         assert!(c.mass.unwrap() > 0.0);
+    }
+
+    #[test]
+    fn test_fast_path_rejects_trails_and_giant_regions() {
+        // A giant bright disc (> max_pixels) and a thin streak must not
+        // outrank the real star in the fast path's brightest-first output.
+        // bg_grid is set to the frame size so the coarse background cannot
+        // absorb the disc (at default grid sizes, structure larger than a
+        // block is background-subtracted away before the filters see it).
+        let (width, height) = (256u32, 256u32);
+        let mut pixels = render_stars(
+            width,
+            height,
+            100.0,
+            0.0,
+            4.0,
+            1.5,
+            &[(190.0, 190.0, 800.0)],
+        );
+        // Flat disc, radius 60 → ~11.3k px, over the default max_pixels.
+        for row in 0..height as usize {
+            for col in 0..width as usize {
+                let (dx, dy) = (col as f32 - 80.0, row as f32 - 80.0);
+                if dx * dx + dy * dy < 60.0 * 60.0 {
+                    pixels[row * 256 + col] += 500.0;
+                }
+            }
+        }
+        // Thin bright streak (a trail segment): 60 px long, 1 px tall,
+        // clear of both the disc and the star.
+        for col in 20..80 {
+            pixels[230 * 256 + col] += 500.0;
+        }
+
+        let base = FastCentroidConfig {
+            sigma_threshold: 5.0,
+            bg_grid: 256,
+            ..Default::default()
+        };
+        // Default max_pixels rejects the disc; the streak needs elongation.
+        let res = extract_centroids_fast(&pixels, width, height, &base).unwrap();
+        assert_eq!(res.centroids.len(), 2, "star + streak expected");
+        assert!(
+            res.centroids
+                .iter()
+                .all(|c| (c.x - (80.0 - 127.5)).abs() > 10.0),
+            "disc should be rejected by max_pixels"
+        );
+
+        let gated = FastCentroidConfig {
+            max_elongation: Some(3.0),
+            min_pixels: 5,
+            ..base
+        };
+        let res = extract_centroids_fast(&pixels, width, height, &gated).unwrap();
+        assert_eq!(res.centroids.len(), 1, "only the real star should survive");
+        assert!(
+            (res.centroids[0].x - (190.0 - 127.5)).abs() < 1.0
+                && (res.centroids[0].y - (190.0 - 127.5)).abs() < 1.0
+        );
+        assert!(res.centroids[0].cov.is_some(), "fast path now reports cov");
+    }
+
+    #[test]
+    fn test_log_parabola_subpixel_accuracy() {
+        // A Gaussian PSF is exactly quadratic in log intensity, so the
+        // refined position of a bright, point-sampled Gaussian star must be
+        // accurate at every sub-pixel phase — including the quarter-pixel
+        // phases where the linear-intensity parabola's S-curve bias peaks
+        // (~0.03-0.06 px at this PSF width, which would fail this bound).
+        let (width, height) = (64u32, 64u32);
+        for &(px, py) in &[
+            (30.0_f32, 31.0_f32),
+            (30.25, 31.25),
+            (30.5, 31.4),
+            (29.75, 30.6),
+        ] {
+            let pixels = render_stars(width, height, 100.0, 0.0, 2.0, 1.3, &[(px, py, 5000.0)]);
+            let cfg = CentroidExtractionConfig {
+                sigma_threshold: 5.0,
+                local_bg_block_size: None,
+                matched_filter_sigma: None,
+                ..Default::default()
+            };
+            let res = extract_centroids_from_raw(&pixels, width, height, &cfg).unwrap();
+            assert_eq!(res.centroids.len(), 1, "phase ({px}, {py})");
+            let c = &res.centroids[0];
+            let (ex, ey) = (c.x - (px - 31.5), c.y - (py - 31.5));
+            assert!(
+                ex.abs() < 0.02 && ey.abs() < 0.02,
+                "phase ({px}, {py}): error ({ex:.4}, {ey:.4}) px"
+            );
+        }
     }
 
     #[test]

--- a/src/solver/solve.rs
+++ b/src/solver/solve.rs
@@ -640,12 +640,20 @@ impl SolverDatabase {
                     // Every verified candidate consumes one unit of the
                     // multiple-comparison budget (`candidates_tested` is the
                     // sequential-Bonferroni divisor of the acceptance test
-                    // below). The pre-gate itself is deliberately *uncorrected*:
-                    // it only decides whether the candidate is promising
-                    // enough to refine — acceptance happens after
-                    // re-verification of the refined attitude.
+                    // below). The pre-gate itself is deliberately loose: its
+                    // only job is to keep hopeless candidates away from the
+                    // (relatively expensive) refinement — acceptance is
+                    // decided by re-verifying the *refined* attitude at a
+                    // tightened radius, which separates true from false
+                    // candidates far more sharply than this coarse-radius
+                    // p-value can. Hostile-but-solvable fields depend on the
+                    // slack: e.g. a galaxy-cluster frame where only ~8 of the
+                    // 50 brightest centroids are catalog stars scores ~1e-2
+                    // here yet re-verifies decisively once refined. The
+                    // ceiling never tightens below the user's budget.
+                    const PREGATE_CEILING: f64 = 1e-2;
                     *candidates_tested += 1;
-                    if prob_mismatch >= config.match_threshold {
+                    if prob_mismatch >= config.match_threshold.max(PREGATE_CEILING) {
                         continue;
                     }
 
@@ -874,7 +882,6 @@ impl SolverDatabase {
             trials as u32,
             1.0 - prob_single.min(1.0),
         );
-
         (matches, prob_mismatch)
     }
 

--- a/tests/skyview_solve_test.rs
+++ b/tests/skyview_solve_test.rs
@@ -387,7 +387,7 @@ fn test_skyview_fits_solve() {
         // sigma threshold. After local BG subtraction the residual is
         // mostly noise + point sources.
         let extract_config = CentroidExtractionConfig {
-            sigma_threshold: 10.0,
+            sigma_threshold: 6.0,
             min_pixels: 3,
             max_pixels: 10000,
             max_centroids: Some(200),

--- a/tests/skyview_solve_test.rs
+++ b/tests/skyview_solve_test.rs
@@ -397,6 +397,7 @@ fn test_skyview_fits_solve() {
             local_bg_block_size: Some(64),
             max_elongation: Some(3.0),
             matched_filter_sigma: None,
+            ..Default::default()
         };
 
         let extraction =

--- a/tests/skyview_solve_test.rs
+++ b/tests/skyview_solve_test.rs
@@ -397,6 +397,10 @@ fn test_skyview_fits_solve() {
             local_bg_block_size: Some(64),
             max_elongation: Some(3.0),
             matched_filter_sigma: None,
+            // DSS cutouts at 17.6″/px have a sub-pixel PSF: real stars are
+            // geometrically indistinguishable from hot pixels, so the
+            // sharpness gate must be off for this (edge-case) plate scale.
+            max_sharpness: None,
             ..Default::default()
         };
 

--- a/tests/tess_solve_test.rs
+++ b/tests/tess_solve_test.rs
@@ -454,6 +454,7 @@ fn test_tess_fits_solve() {
             local_bg_block_size: Some(128),
             max_elongation: Some(30.0),
             matched_filter_sigma: None,
+            ..Default::default()
         };
 
         let extraction = tetra3::extract_centroids_from_raw(
@@ -613,6 +614,7 @@ fn bench_fast_vs_ccl_extraction() {
             bg_grid: 128,
             min_pixels: 3,
             max_centroids: None,
+            ..Default::default()
         };
 
         let best = |f: &dyn Fn() -> usize| -> (f64, usize) {
@@ -775,6 +777,7 @@ fn test_tess_distortion_fit_and_center_accuracy() {
             local_bg_block_size: Some(128),
             max_elongation: Some(30.0),
             matched_filter_sigma: None,
+            ..Default::default()
         };
 
         let extraction = tetra3::extract_centroids_from_raw(
@@ -976,6 +979,7 @@ fn test_tess_multi_image_calibration() {
         local_bg_block_size: Some(16),
         max_elongation: Some(6.0),
         matched_filter_sigma: None,
+        ..Default::default()
     };
 
     struct ImageData {

--- a/tests/tess_solve_test.rs
+++ b/tests/tess_solve_test.rs
@@ -444,7 +444,7 @@ fn test_tess_fits_solve() {
         // TESS images have high background (~150-200 DN). Saturated stars
         // create elongated blobs, so max_elongation is set high (30.0).
         let extract_config = CentroidExtractionConfig {
-            sigma_threshold: 250.0,
+            sigma_threshold: 150.0,
             min_pixels: 3,
             max_pixels: 10000,
             max_centroids: None,
@@ -599,7 +599,7 @@ fn bench_fast_vs_ccl_extraction() {
         let true_boresight = radec_to_uvec(b_ra, b_dec);
 
         let ccl_config = CentroidExtractionConfig {
-            sigma_threshold: 250.0,
+            sigma_threshold: 150.0,
             min_pixels: 3,
             max_pixels: 10000,
             local_bg_block_size: Some(128),
@@ -765,7 +765,7 @@ fn test_tess_distortion_fit_and_center_accuracy() {
 
         // ── Extract centroids ──
         let extract_config = CentroidExtractionConfig {
-            sigma_threshold: 250.0,
+            sigma_threshold: 150.0,
             min_pixels: 3,
             max_pixels: 10000,
             max_centroids: None,
@@ -966,7 +966,7 @@ fn test_tess_multi_image_calibration() {
 
     // ── Extract centroids from all images up front ──
     let extract_config = CentroidExtractionConfig {
-        sigma_threshold: 300.0,
+        sigma_threshold: 180.0,
         min_pixels: 3,
         max_pixels: 10000,
         max_centroids: None,


### PR DESCRIPTION
## Summary

Works through the centroid-extraction research findings (stage 3 of the review-driven work). Stacked on #43 (`fix/verification-stats`) — retarget after it merges.

### Correctness

- **Noise estimator bug (CCL path)**: sigma was the RMS of below-median pixels about their own mean — for Gaussian noise only ≈0.60σ — instead of about the median (the estimator the docstring described and the fast path already used). A configured 5σ threshold was really ~3σ, and the two paths disagreed for the same setting. **Migration**: CCL `sigma_threshold` now means true sigmas; multiply configured values by ≈0.6 to keep the previous depth (test configs retuned; equivalence verified on the hostile Virgo field: best true candidate 17/50 both before@10σ and after@6σ).
- **Solver pre-gate** (fallout from the above): the pre-refinement gate is now a pure cost filter (`p < max(match_threshold, 1e-2)`) — acceptance belongs to the post-refinement re-verification. +6% no-match latency, 0 false accepts.
- **Block-median sample filter**: only non-finite samples excluded (the old `v > 0.0` filter biased the background up on dark-subtracted frames).

### Detection & accuracy

- **Matched filter on by default** (`Some(1.5)`), convolving the **unclamped** residual (the clamped input rectified noise into a DC offset), with the detection threshold **auto-scaled by the kernel's noise-suppression factor** — `sigma_threshold` means "sigmas of the thresholded image's noise" with the filter on or off; no retuning to toggle. ~2× point-source SNR (≈0.75 mag depth). Tests pin faint-star recovery at constant threshold and zero noise false positives.
- **Log-scale peak refinement**: the 3×3 parabola fits ln(v) when all nine samples are positive (a Gaussian is exactly quadratic in log), removing the linear fit's S-curve bias. **TESS multi-sector calibration: pooled fit 0.132 → 0.077 px (−42%); per-sector solve RMSE 2.5–2.9″ → 1.0–1.7″.** A unit test sweeps sub-pixel phases with a bound the linear fit fails.
- **Hot-pixel sharpness gate** (`max_sharpness`, default 0.9): DAOFIND-style, measured on the unfiltered image so filter-smeared hot pixels are caught — the defense that makes the matched-filter default safe. Sub-pixel-PSF data (e.g. the 17.6″/px skyview DSS cutouts) opts out with `None`, documented.
- **Saturation guard** (`saturation_level`, opt-in): saturated peaks skip parabola refinement (flat tops have no meaningful sub-pixel maximum), keeping CoM.
- **Fast-path robustness**: inline second moments (union-find-merged) give it `max_pixels` (default 10000 — a trail/bloom can't be the *top* centroid anymore), opt-in `max_elongation`, and a populated `Centroid.cov`.

### Speed

- Block medians from a **phase-staggered stride subsample** (diagonal lattice — covers all column-residue classes, so column-periodic FPN doesn't alias; SE ≲0.08σ).
- **Fused front-end**: background grid interpolated on the fly in one residual pass (no materialized background buffer, no subtract passes, no blur-input copy); noise stats from subsampled bilinear residuals (same estimator + reference surface). Fast sweep hoists the row-constant bilinear half.
- **CCL extraction 71.5 → ~42 ms** on 2048² TESS frames (−41%); fast path 25 → 23 ms.

## Validation

Full suites green throughout (75 unit — 8 new; integration incl. 1000-field statistical; skyview 10/10; TESS 3/3 incl. multi-sector calibration, which *improved* to 0.077 px pooled); `clippy --all-targets --all-features` clean; `image,parallel` builds verified. Python bindings + stubs updated for all new knobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)