### PR TITLE
Ensure tetra3rs can compile in WASM

### DIFF
--- a/src/solver/clock.rs
+++ b/src/solver/clock.rs
@@ -1,0 +1,43 @@
+//! Portable monotonic clock for the solve path.
+//!
+//! On native targets this is exactly [`std::time::Instant`]. On
+//! `wasm32-unknown-unknown` there is no monotonic clock in `std` —
+//! `std::time::Instant::now()` aborts the module — so we substitute a no-op
+//! clock that always reports zero elapsed time.
+//!
+//! The practical consequence for a WASM build: `solve_time_ms` in the result is
+//! reported as `0.0`, and [`SolveConfig::solve_timeout_ms`] never trips (elapsed
+//! is always below any positive budget). Measure wall-clock time on the host
+//! (e.g. `performance.now()`) instead. A production browser build that needs a
+//! real in-WASM clock can swap this for a `wasm-bindgen`-backed
+//! `performance.now()` source (see the `web-time` crate).
+//!
+//! [`SolveConfig::solve_timeout_ms`]: super::SolveConfig::solve_timeout_ms
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) use std::time::Instant;
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) use wasm_clock::Instant;
+
+#[cfg(target_arch = "wasm32")]
+mod wasm_clock {
+    use std::time::Duration;
+
+    /// Drop-in stand-in for `std::time::Instant` on `wasm32-unknown-unknown`,
+    /// where `std` has no monotonic clock. Always reports zero elapsed time.
+    #[derive(Debug, Clone, Copy)]
+    pub struct Instant;
+
+    impl Instant {
+        #[inline]
+        pub fn now() -> Self {
+            Instant
+        }
+
+        #[inline]
+        pub fn elapsed(&self) -> Duration {
+            Duration::ZERO
+        }
+    }
+}

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -24,6 +24,7 @@ macro_rules! timed {
     }};
 }
 
+pub(crate) mod clock;
 pub(crate) mod combinations;
 pub(crate) mod database;
 pub(crate) mod matching;

--- a/src/solver/solve.rs
+++ b/src/solver/solve.rs
@@ -11,7 +11,7 @@
 //!    d. Accept if false-positive probability is below threshold.
 
 use std::borrow::Cow;
-use std::time::Instant;
+use super::clock::Instant;
 
 use numeris::{Matrix3, Quaternion, Vector3};
 use tracing::{debug, warn};

--- a/src/solver/track.rs
+++ b/src/solver/track.rs
@@ -15,7 +15,7 @@
 //! This succeeds with as few as 3 matched stars (LIS needs 4) and is robust to
 //! pattern-hash failures from sparse / low-SNR fields.
 
-use std::time::Instant;
+use super::clock::Instant;
 
 use numeris::Vector3;
 use tracing::debug;


### PR DESCRIPTION
WASM allows to run this solver inside the browser
the only caveat is the code runs in a sandbox
without an access to time

this change ensures stubs are used only when compiled to WASM this change is NO-OP for all other platforms

Bigger picture
As a proof of concept I created a single page web application which is using tetra3rs compiled in WASM to perform plate solving on the client side. These applications can run on desktop and mobile alike