### PR TITLE
Robustness sweep: validate at trust boundaries, fix reachable panics (0.10.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,23 @@
 # Changelog
 
-## Unreleased
+## 0.10.0
 
 Robustness sweep: validate at every trust boundary (file load, pickle,
 public constructors) so corrupt data and degenerate arguments fail with a
 descriptive error instead of a deferred panic, hang, or silently-wrong
 result. No solver-algorithm changes; all outputs on valid inputs are
 unchanged.
+
+### Upgrading from 0.9
+
+- `SolverDatabase::to_bytes` returns `crate::Result<Vec<u8>>` — add `?`.
+- Exhaustive matches on `SolveStatus` need a new `InvalidConfig` arm, and
+  solves with a degenerate config (e.g. the `Default::default()`
+  placeholder camera model) now return it instead of `NoMatch`.
+- `CameraModel::from_fov` panics on FOV outside `(0, π)` in release builds
+  too (previously debug-only); Python raises `ValueError`.
+- Corrupt database/camera files and pickles now fail at load
+  (`InvalidInput` / Python `ValueError`) instead of panicking on first use.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,79 @@
 # Changelog
 
+## Unreleased
+
+Robustness sweep: validate at every trust boundary (file load, pickle,
+public constructors) so corrupt data and degenerate arguments fail with a
+descriptive error instead of a deferred panic, hang, or silently-wrong
+result. No solver-algorithm changes; all outputs on valid inputs are
+unchanged.
+
+### Fixed
+
+- **Corrupt/tampered database files and pickles are rejected at load.**
+  `SolverDatabase::load_from_file` (and the Python pickle path) now run a
+  full invariant check — `StarCatalog` spatial-index consistency, pattern
+  entries within the star table, `star_vectors`/`star_catalog_ids` length
+  agreement, and sane `DatabaseProperties` (including
+  `pattern_bins`-vs-`pattern_max_error` consistency, which previously let a
+  crafted file inflate the key enumeration without bound). Previously a file
+  that decoded cleanly could panic out-of-bounds mid-solve. New public
+  `SolverDatabase::validate` / `StarCatalog::validate`.
+  `CameraModel::load_from_file` and the pickle paths for `CameraModel`,
+  `RadialDistortion`, `PolynomialDistortion`, `SolveResult`, and
+  `CalibrateResult` validate the same way (Python: `ValueError`).
+- **Infinite loop / unbounded memory in the FOV sweep** with
+  `fov_max_error_rad: Some(f32::INFINITY)` (or any value large enough to
+  stall the f32 step accumulation). The sweep now clamps to π and detects
+  step saturation. Candidate matches implying a FOV outside `(0, π)` are
+  also skipped (previously they degenerated the verification statistics).
+- **Hipparcos parser panicked on multi-byte UTF-8** straddling a fixed-width
+  column boundary; such lines are now skipped like any other malformed
+  record.
+- **`PolynomialDistortion` order/coefficient mismatches panicked
+  out-of-bounds** on first use. `num_coeffs` no longer wraps for absurd
+  orders (this also closes the Python hole where
+  `PolynomialDistortion(order=2**32-1, a_coeffs=[], b_coeffs=[])`
+  constructed and panicked on `.distort()`); constructors bound `order` by
+  the new `MAX_POLY_ORDER` (12); `validate()` checks the invariants at
+  deserialization boundaries. The debug-only assert on the Newton Jacobian
+  in `undistort` (which fired on NaN input) is removed — the existing
+  release-path bailout handles it.
+- **Single-image `calibrate_camera` returned a fabricated perfect result**
+  (identity distortion, RMSE 0, 0 inliers) when the fit had too few matched
+  points, contradicting its documented error contract. It now returns
+  `InvalidInput` like the multi-image path.
+- **Gaia binary loader**: the star count no longer silently truncates on
+  32-bit targets, and records with non-finite ra/dec/mag/pm are skipped
+  with a warning instead of silently poisoning the spatial index.
+  32-bit `width*height` overflow in the extraction buffer check is also
+  closed.
+
+### Changed
+
+- **`CameraModel::from_fov` and `StarCatalog::new` validate in release
+  builds** (documented panics). Previously `from_fov` checked only in debug,
+  so release builds accepted `fov=0`/`≥180°`/NaN and silently produced
+  infinite/negative/NaN focal lengths. From Python these are `ValueError`s
+  (as are zero image dimensions, degenerate `CameraModel` constructor args,
+  and non-finite distortion coefficients).
+- **`SolverDatabase::to_bytes` returns `crate::Result<Vec<u8>>`** (breaking)
+  instead of panicking on serialization failure.
+- **`calibrate_camera` argument errors are `Err(InvalidInput)`** instead of
+  panics (mismatched slice lengths, polynomial order outside `[2, 6]`). The
+  lower-level `fit_*_distortion` functions keep their asserts, now
+  documented.
+- **Generation limits**: `GenerateDatabaseConfig::validate` bounds
+  `catalog_nside` by `MAX_NSIDE` (1024) and requires a plausible
+  `epoch_proper_motion_year`; generation errors (instead of OOM) when the
+  lattice would exceed 10⁸ points (tiny `min_fov_deg` × high oversampling).
+  `matched_filter_sigma` above 64 px is rejected (the kernel allocation
+  scales with σ).
+- **Python: the GIL is released during long native calls** —
+  `solve_from_centroids`, `generate_from_gaia`, `calibrate_camera`,
+  `load_from_file`, and both extraction functions — so other Python threads
+  keep running.
+
 ## 0.9.0
 
 ### Upgrading from 0.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,16 @@ unchanged.
 
 ### Changed
 
+- **New `SolveStatus::InvalidConfig` variant** (breaking for exhaustive
+  matches): `solve_from_centroids` now runs the new public
+  `SolveConfig::validate()` first and fails fast with `InvalidConfig`
+  instead of warn-and-proceed to a guaranteed `NoMatch` — for the
+  `Default::default()` placeholder camera model, non-finite
+  `match_radius`/`match_threshold`, non-finite `fov_max_error_rad` /
+  `match_max_error` / `observer_velocity_km_s`, and (when a hint is set) a
+  degenerate `hint_uncertainty_rad`. Python: `SolveFailure.status` gains
+  `'invalid_config'`. The variant is appended after the 0.9 ones, so
+  previously serialized statuses keep their wire values.
 - **`CameraModel::from_fov` and `StarCatalog::new` validate in release
   builds** (documented panics). Previously `from_fov` checked only in debug,
   so release builds accepted `fov=0`/`≥180°`/NaN and silently produced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,11 @@ unchanged.
   `load_from_file`, and both extraction functions — so other Python threads
   keep running.
 
+### Dependencies
+
+- Bumped `numeris` 0.5.14 → 0.5.17.
+- Python bindings: upgraded `pyo3` to 0.29.2 and `numpy` to 0.29.0.
+
 ## 0.9.0
 
 ### Upgrading from 0.8

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,17 @@ Publishing:
 
 TESS images have significant optical distortion and SIP WCS. Science region trimmed from 2136×2078 → 2048×2048.
 
+## Serialization & trust boundaries
+
+All persistence is **postcard + serde** (no rkyv anywhere, despite older notes
+elsewhere): `SolverDatabase` and `CameraModel` files, and every Python pickle.
+Postcard parses untrusted bytes safely, but structure ≠ semantics — cross-field
+invariants are enforced by `validate()` methods (`SolverDatabase`,
+`StarCatalog`, `CameraModel`, `Distortion`/`RadialDistortion`/
+`PolynomialDistortion`), called at every load/pickle boundary. When adding a
+field whose value other code indexes by or divides by, extend the owning
+`validate()`.
+
 ## Data assets (`data/`)
 
 Downloaded on first integration-test run from GCS (`tetra3rs-testvecs` bucket). Not in git.
@@ -138,7 +149,7 @@ Downloaded on first integration-test run from GCS (`tetra3rs-testvecs` bucket). 
 - `hipsolver_10_30.bin` (455M) — main solver database
 - `test_tess_db.bin` (144M), `test_skyview_db.bin` (38M)
 - `gaia_merged.bin` (17M) — binary Gaia+Hipparcos catalog
-- `gaia_merged.csv` (81M) — CSV form (loaded by an in-tree hand-rolled parser; no `csv` crate dep)
+- `gaia_merged.csv` (81M) — CSV form (used by `scripts/`; no in-tree Rust CSV parser — the crate loads only the `.bin` GDR3 format)
 - FITS test images (skyview, TESS). TIFF/JPEG variants exist in the bucket but aren't exercised in CI — the library no longer ships file-format decoders, so callers must decode files themselves before calling `extract_centroids_from_image`.
 
 ## Scripts (`scripts/`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -476,9 +476,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778da78c64ddc928ebf5ad9df5edf0789410ff3bdbf3619aed51cd789a6af1e2"
+checksum = "6a5b15d63a5ff39e378daed0e1340d3a5964703ea9712eb09a0dc66fade996f4"
 dependencies = [
  "libc",
  "ndarray",
@@ -563,9 +563,9 @@ checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "pyo3"
-version = "0.28.3"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+checksum = "4688ddedf473e32662b9b067670129a8afb8c18e351482c70d62ba4a88171e8b"
 dependencies = [
  "libc",
  "once_cell",
@@ -577,18 +577,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.3"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+checksum = "f41027e41b4bd03f6e60f9f417fe24a6341a6bb744edd62b6f709f2a52ea30e9"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.3"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+checksum = "e591a95526fead067432c3b3a33fc74770b87b1e04e73671090d9c2055a2b327"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -596,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.3"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+checksum = "73225868fc1cd84eef2c3c230ddb91273bf1de46aeb8a4248da76d32a0924a1c"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -608,13 +608,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.3"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+checksum = "571575aa3749fa6216757dd47d2a3e7ef360f329a40f0666a9fbd14889024952"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,9 +464,9 @@ dependencies = [
 
 [[package]]
 name = "numeris"
-version = "0.5.14"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5b3135801d7f17db8c67cd7d6dd42f7f05b2255a0a936bfd9f917749fe7596b"
+checksum = "6a842e37f149029e1dd010093efbc5c1ec31aa3497308e62de8229a5d8129f71"
 dependencies = [
  "num-complex",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,7 +890,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tetra3"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "image",
  "numeris",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "tetra3-python"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "numeris",
  "numpy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ postcard = { version = "1.0", features = ["alloc"] }
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "2"
 tracing = { version = "0.1.40", features = ["std"] }
-numeris = { version = "0.5.14", features = ["std", "serde", "optim"] }
+numeris = { version = "0.5.17", features = ["std", "serde", "optim"] }
 image = { version = "0.25", optional = true, default-features = false }
 rayon = { version = "1", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = [
     "pattern-recognition",
 ]
 name = "tetra3"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Rust implementation of Tetra3: Fast and robust star plate solver"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tetra3rs"
-version = "0.9.0"
+version = "0.10.0"
 description = "Fast star plate solver written in Rust"
 requires-python = ">=3.10"
 dependencies = ["numpy", "gaia-catalog<1.0"]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tetra3-python"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 publish = false
 

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -14,7 +14,7 @@ pyo3 = { version = "0.29.2", features = ["extension-module"] }
 numpy = "0.29.0"
 postcard = { version = "1.0", features = ["alloc"] }
 serde = { version = "1.0", features = ["derive"] }
-numeris = { version = "0.5.14", features = ["std"] }
+numeris = { version = "0.5.17", features = ["std"] }
 
 [build-dependencies]
 pyo3-build-config = "0.29.2"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -10,11 +10,11 @@ crate-type = ["cdylib"]
 
 [dependencies]
 tetra3 = { path = "..", features = ["image"] }
-pyo3 = { version = "0.28.1", features = ["extension-module"] }
-numpy = "0.28.0"
+pyo3 = { version = "0.29.2", features = ["extension-module"] }
+numpy = "0.29.0"
 postcard = { version = "1.0", features = ["alloc"] }
 serde = { version = "1.0", features = ["derive"] }
 numeris = { version = "0.5.14", features = ["std"] }
 
 [build-dependencies]
-pyo3-build-config = "0.28.1"
+pyo3-build-config = "0.29.2"

--- a/python/src/calibrate.rs
+++ b/python/src/calibrate.rs
@@ -67,6 +67,12 @@ impl PyCalibrateResult {
     #[staticmethod]
     fn _from_pickle_bytes(data: &[u8]) -> PyResult<Self> {
         let inner = crate::helpers::from_postcard_bytes::<CalibrateResult>(data)?;
+        // The embedded camera model's distortion is evaluated on use;
+        // enforce its invariants against tampered pickle bytes.
+        inner
+            .camera_model
+            .validate()
+            .map_err(crate::helpers::map_tetra3_err)?;
         Ok(Self { inner })
     }
 

--- a/python/src/camera_model.rs
+++ b/python/src/camera_model.rs
@@ -44,16 +44,18 @@ impl PyCameraModel {
             Some(obj) => extract_distortion(obj)?,
             None => Distortion::None,
         };
-        Ok(Self {
-            inner: CameraModel {
-                focal_length_px,
-                image_width,
-                image_height,
-                crpix: crpix.unwrap_or([0.0, 0.0]),
-                parity_flip,
-                distortion: dist,
-            },
-        })
+        let inner = CameraModel {
+            focal_length_px,
+            image_width,
+            image_height,
+            crpix: crpix.unwrap_or([0.0, 0.0]),
+            parity_flip,
+            distortion: dist,
+        };
+        // Zero/NaN focal length or zero dimensions silently poison every
+        // downstream pixel scale — reject at construction.
+        inner.validate().map_err(crate::helpers::map_tetra3_err)?;
+        Ok(Self { inner })
     }
 
     /// Create a camera model from a horizontal field of view and image dimensions.
@@ -67,10 +69,22 @@ impl PyCameraModel {
     ///     CameraModel with no distortion, crpix=[0,0], parity_flip=False.
     #[staticmethod]
     #[pyo3(signature = (fov_deg, image_width, image_height))]
-    fn from_fov(fov_deg: f64, image_width: u32, image_height: u32) -> Self {
-        Self {
-            inner: CameraModel::from_fov(fov_deg.to_radians(), image_width, image_height),
+    fn from_fov(fov_deg: f64, image_width: u32, image_height: u32) -> PyResult<Self> {
+        // CameraModel::from_fov panics (by contract) outside (0, 180)°; from
+        // Python that must be a ValueError instead.
+        if !(fov_deg.is_finite() && fov_deg > 0.0 && fov_deg < 180.0) {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "fov_deg must be in (0, 180), got {fov_deg}"
+            )));
         }
+        if image_width == 0 || image_height == 0 {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "image dimensions must be non-zero, got {image_width}x{image_height}"
+            )));
+        }
+        Ok(Self {
+            inner: CameraModel::from_fov(fov_deg.to_radians(), image_width, image_height),
+        })
     }
 
     /// Focal length in pixels.
@@ -184,6 +198,9 @@ impl PyCameraModel {
     #[staticmethod]
     fn _from_pickle_bytes(data: &[u8]) -> PyResult<Self> {
         let inner = crate::helpers::from_postcard_bytes::<CameraModel>(data)?;
+        // Tampered pickle bytes can decode into a model that panics (or
+        // divides by zero) on first use — enforce the invariants here.
+        inner.validate().map_err(crate::helpers::map_tetra3_err)?;
         Ok(Self { inner })
     }
 

--- a/python/src/distortion.rs
+++ b/python/src/distortion.rs
@@ -70,10 +70,11 @@ impl PyRadialDistortion {
     ///         image-center-origin frame. Default (0, 0).
     #[new]
     #[pyo3(signature = (k1 = 0.0, k2 = 0.0, k3 = 0.0, p1 = 0.0, p2 = 0.0, center = (0.0, 0.0)))]
-    fn new(k1: f64, k2: f64, k3: f64, p1: f64, p2: f64, center: (f64, f64)) -> Self {
-        Self {
-            inner: RadialDistortion::with_center(center.0, center.1, k1, k2, k3, p1, p2),
-        }
+    fn new(k1: f64, k2: f64, k3: f64, p1: f64, p2: f64, center: (f64, f64)) -> PyResult<Self> {
+        let inner = RadialDistortion::with_center(center.0, center.1, k1, k2, k3, p1, p2);
+        // A NaN coefficient silently poisons every corrected coordinate.
+        inner.validate().map_err(crate::helpers::map_tetra3_err)?;
+        Ok(Self { inner })
     }
 
     #[getter]
@@ -125,6 +126,7 @@ impl PyRadialDistortion {
     #[staticmethod]
     fn _from_pickle_bytes(data: &[u8]) -> PyResult<Self> {
         let inner = crate::helpers::from_postcard_bytes::<RadialDistortion>(data)?;
+        inner.validate().map_err(crate::helpers::map_tetra3_err)?;
         Ok(Self { inner })
     }
 
@@ -208,6 +210,16 @@ impl PyPolynomialDistortion {
         bp_coeffs: Option<Vec<f64>>,
     ) -> PyResult<Self> {
         let _ = (ap_coeffs, bp_coeffs); // legacy inverse coeffs are no longer used
+                                        // PolynomialDistortion::new panics (by contract) above MAX_POLY_ORDER;
+                                        // from Python that must be a ValueError. (This also closes the old
+                                        // u32-wrap hole where order=2**32-1 constructed with empty
+                                        // coefficient lists and panicked on first distort().)
+        if order > tetra3::distortion::MAX_POLY_ORDER {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "order must be <= {}, got {order}",
+                tetra3::distortion::MAX_POLY_ORDER
+            )));
+        }
         let n = poly_num_coeffs(order);
         if a_coeffs.len() != n || b_coeffs.len() != n {
             return Err(pyo3::exceptions::PyValueError::new_err(format!(
@@ -218,9 +230,10 @@ impl PyPolynomialDistortion {
                 b_coeffs.len()
             )));
         }
-        Ok(Self {
-            inner: PolynomialDistortion::new(order, scale, a_coeffs, b_coeffs),
-        })
+        let inner = PolynomialDistortion::new(order, scale, a_coeffs, b_coeffs);
+        // Catches non-finite coefficients / non-positive scale.
+        inner.validate().map_err(crate::helpers::map_tetra3_err)?;
+        Ok(Self { inner })
     }
 
     #[getter]
@@ -280,6 +293,9 @@ impl PyPolynomialDistortion {
     #[staticmethod]
     fn _from_pickle_bytes(data: &[u8]) -> PyResult<Self> {
         let inner = crate::helpers::from_postcard_bytes::<PolynomialDistortion>(data)?;
+        // Corrupt pickle bytes can decode a model whose coefficient count
+        // disagrees with its order — which panics OOB on first use.
+        inner.validate().map_err(crate::helpers::map_tetra3_err)?;
         Ok(Self { inner })
     }
 

--- a/python/src/extraction.rs
+++ b/python/src/extraction.rs
@@ -276,9 +276,14 @@ pub(crate) fn extract_centroids(
         border_margin,
     };
 
-    let result =
-        tetra3::centroid_extraction::extract_centroids_from_raw(&pixels, width, height, &config)
-            .map_err(crate::helpers::map_tetra3_err)?;
+    // The image was copied into a pure-Rust buffer above; release the GIL for
+    // the (potentially long) extraction so other Python threads keep running.
+    let result = image
+        .py()
+        .detach(|| {
+            tetra3::centroid_extraction::extract_centroids_from_raw(&pixels, width, height, &config)
+        })
+        .map_err(crate::helpers::map_tetra3_err)?;
 
     Ok(PyExtractionResult {
         inner: result.into(),
@@ -371,9 +376,14 @@ pub(crate) fn extract_centroids_fast(
         border_margin,
     };
 
-    let result =
-        tetra3::centroid_extraction::extract_centroids_fast(&pixels, width, height, &config)
-            .map_err(crate::helpers::map_tetra3_err)?;
+    // Input already copied to a pure-Rust buffer; release the GIL during the
+    // sweep.
+    let result = image
+        .py()
+        .detach(|| {
+            tetra3::centroid_extraction::extract_centroids_fast(&pixels, width, height, &config)
+        })
+        .map_err(crate::helpers::map_tetra3_err)?;
 
     Ok(PyExtractionResult {
         inner: result.into(),

--- a/python/src/solve_result.rs
+++ b/python/src/solve_result.rs
@@ -262,6 +262,13 @@ impl PySolveResult {
     #[staticmethod]
     fn _from_pickle_bytes(data: &[u8]) -> PyResult<Self> {
         let solution = crate::helpers::from_postcard_bytes::<Solution>(data)?;
+        // The embedded camera model drives pixel_to_world / world_to_pixel;
+        // tampered bytes could give it an inconsistent distortion that
+        // panics on first use.
+        solution
+            .camera_model
+            .validate()
+            .map_err(crate::helpers::map_tetra3_err)?;
         Ok(Self::from_solution(solution))
     }
 

--- a/python/src/solve_result.rs
+++ b/python/src/solve_result.rs
@@ -448,6 +448,7 @@ impl PySolveFailure {
             SolveStatus::NoMatch => "no_match",
             SolveStatus::Timeout => "timeout",
             SolveStatus::TooFew => "too_few",
+            SolveStatus::InvalidConfig => "invalid_config",
         }
     }
 }
@@ -456,7 +457,9 @@ impl PySolveFailure {
 impl PySolveFailure {
     /// Why the solve produced no solution: ``'no_match'`` (all pattern
     /// combinations exhausted), ``'timeout'`` (``solve_timeout_ms`` reached),
-    /// or ``'too_few'`` (fewer than 4 usable centroids).
+    /// ``'too_few'`` (fewer than 4 usable centroids), or
+    /// ``'invalid_config'`` (degenerate camera model or non-finite matching
+    /// parameters — nothing was searched).
     #[getter]
     fn status(&self) -> &'static str {
         self.status_str()

--- a/python/src/solver_database.rs
+++ b/python/src/solver_database.rs
@@ -204,8 +204,8 @@ impl PySolverDatabase {
     /// Returns:
     ///     SolveResult on success, or a (falsy) SolveFailure carrying the
     ///     failure reason (``status``: ``'no_match'`` / ``'timeout'`` /
-    ///     ``'too_few'``) and ``solve_time_ms``. Use ``if result:`` to
-    ///     distinguish the two.
+    ///     ``'too_few'`` / ``'invalid_config'``) and ``solve_time_ms``. Use
+    ///     ``if result:`` to distinguish the two.
     #[pyo3(signature = (
         centroids,
         fov_estimate_deg = None,

--- a/python/src/solver_database.rs
+++ b/python/src/solver_database.rs
@@ -96,7 +96,10 @@ impl PySolverDatabase {
             epoch_proper_motion_year,
             catalog_nside,
         };
-        let db = SolverDatabase::generate_from_gaia(&resolved_path, &config)
+        // Generation runs for seconds to minutes on pure-Rust data; release
+        // the GIL so other Python threads keep running.
+        let db = py
+            .detach(|| SolverDatabase::generate_from_gaia(&resolved_path, &config))
             .map_err(crate::helpers::map_tetra3_err)?;
         Ok(PySolverDatabase { inner: db })
     }
@@ -109,10 +112,16 @@ impl PySolverDatabase {
     }
 
     /// Load a database from a file.
+    ///
+    /// Raises OSError for file problems and ValueError when the file decodes
+    /// but fails the database's consistency validation (corrupt/tampered data
+    /// that would otherwise crash mid-solve).
     #[staticmethod]
-    fn load_from_file(path: &str) -> PyResult<Self> {
-        let db = SolverDatabase::load_from_file(path)
-            .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))?;
+    fn load_from_file(py: Python<'_>, path: &str) -> PyResult<Self> {
+        let path = path.to_string();
+        let db = py
+            .detach(move || SolverDatabase::load_from_file(&path))
+            .map_err(crate::helpers::map_tetra3_err)?;
         Ok(PySolverDatabase { inner: db })
     }
 
@@ -254,7 +263,16 @@ impl PySolverDatabase {
         // absent do we build a pinhole model — and only then are fov_estimate_*
         // and the image dimensions needed (and required).
         let cam = match camera_model {
-            Some(py_cam) => py_cam.inner,
+            Some(py_cam) => {
+                // A degenerate model (zero/NaN focal length, zero dimensions,
+                // inconsistent distortion) can only produce a guaranteed
+                // NoMatch or a panic deep in the solver — reject it here.
+                py_cam
+                    .inner
+                    .validate()
+                    .map_err(crate::helpers::map_tetra3_err)?;
+                py_cam.inner
+            }
             None => {
                 let fov_rad = exactly_one_angle_rad(
                     fov_estimate_deg,
@@ -262,8 +280,24 @@ impl PySolverDatabase {
                     "Specify exactly one of fov_estimate_deg or fov_estimate_rad, not both",
                     "Must specify fov_estimate_deg or fov_estimate_rad (or pass camera_model)",
                 )?;
+                // CameraModel::from_fov panics (by contract) outside (0, π);
+                // from Python that must be a ValueError instead.
+                if !(fov_rad.is_finite()
+                    && fov_rad > 0.0
+                    && (fov_rad as f64) < std::f64::consts::PI)
+                {
+                    return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                        "fov_estimate must be in (0, 180) degrees, got {} rad",
+                        fov_rad
+                    )));
+                }
                 let (img_width, img_height) =
                     resolve_image_dims(image_shape, image_width, image_height)?;
+                if img_width == 0 || img_height == 0 {
+                    return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                        "image dimensions must be non-zero, got {img_width}x{img_height}"
+                    )));
+                }
                 CameraModel::from_fov(fov_rad as f64, img_width, img_height)
             }
         };
@@ -296,7 +330,9 @@ impl PySolverDatabase {
             strict_hint,
         };
 
-        let result = self.inner.solve_from_centroids(&centroid_vec, &config);
+        // The solve can run up to its timeout (default 5 s) on pure-Rust data;
+        // release the GIL so other Python threads keep running.
+        let result = py.detach(|| self.inner.solve_from_centroids(&centroid_vec, &config));
 
         match result {
             Ok(solution) => Ok(PySolveResult::from_solution(solution)
@@ -415,7 +451,11 @@ impl PySolverDatabase {
     }
 
     fn __reduce__(slf: &Bound<'_, Self>) -> PyResult<(Py<PyAny>, (Vec<u8>,))> {
-        let bytes = slf.borrow().inner.to_bytes();
+        let bytes = slf
+            .borrow()
+            .inner
+            .to_bytes()
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
         let from_bytes = slf.get_type().getattr("_from_pickle_bytes")?;
         Ok((from_bytes.unbind(), (bytes,)))
     }
@@ -424,6 +464,10 @@ impl PySolverDatabase {
     fn _from_pickle_bytes(data: &[u8]) -> PyResult<Self> {
         let inner = postcard::from_bytes::<SolverDatabase>(data)
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+        // Corrupt pickle bytes can decode into a structurally-valid database
+        // whose indices panic mid-solve; enforce the same invariants as
+        // load_from_file (ValueError instead of a deferred PanicException).
+        inner.validate().map_err(crate::helpers::map_tetra3_err)?;
         Ok(Self { inner })
     }
 
@@ -566,7 +610,7 @@ impl PySolverDatabase {
     #[allow(clippy::too_many_arguments)]
     fn calibrate_camera<'py>(
         &self,
-        _py: Python<'py>,
+        py: Python<'py>,
         solve_results: &Bound<'py, pyo3::PyAny>,
         centroids: &Bound<'py, pyo3::PyAny>,
         image_width: Option<u32>,
@@ -611,15 +655,20 @@ impl PySolverDatabase {
             convergence_threshold_px,
         };
 
-        let result = calibrate_camera(
-            &sr_refs,
-            &cent_refs,
-            &self.inner,
-            img_width,
-            img_height,
-            &config,
-        )
-        .map_err(crate::helpers::map_tetra3_err)?;
+        // Calibration iterates WCS refinement over all images on pure-Rust
+        // data; release the GIL for the duration.
+        let result = py
+            .detach(|| {
+                calibrate_camera(
+                    &sr_refs,
+                    &cent_refs,
+                    &self.inner,
+                    img_width,
+                    img_height,
+                    &config,
+                )
+            })
+            .map_err(crate::helpers::map_tetra3_err)?;
 
         Ok(PyCalibrateResult { inner: result })
     }

--- a/python/tests/test_basic.py
+++ b/python/tests/test_basic.py
@@ -491,3 +491,48 @@ class TestExtractCentroids:
         result2 = pickle.loads(pickle.dumps(result))
         assert result2.image_width == result.image_width
         assert len(result2.centroids) == len(result.centroids)
+
+
+class TestArgumentValidation:
+    """Regression tests: degenerate arguments raise ValueError instead of
+    panicking (PanicException) or silently poisoning downstream math."""
+
+    def test_from_fov_rejects_degenerate_fov(self):
+        for bad_fov in [0.0, -10.0, 180.0, 360.0, float("nan"), float("inf")]:
+            with pytest.raises(ValueError):
+                tetra3rs.CameraModel.from_fov(bad_fov, 1024, 768)
+        with pytest.raises(ValueError):
+            tetra3rs.CameraModel.from_fov(10.0, 0, 768)
+
+    def test_camera_model_rejects_degenerate_intrinsics(self):
+        with pytest.raises(ValueError):
+            tetra3rs.CameraModel(0.0, 1024, 768)
+        with pytest.raises(ValueError):
+            tetra3rs.CameraModel(float("nan"), 1024, 768)
+        with pytest.raises(ValueError):
+            tetra3rs.CameraModel(5000.0, 0, 768)
+
+    def test_polynomial_distortion_rejects_huge_order(self):
+        # Used to construct via u32 wrap-around and panic on first distort().
+        with pytest.raises(ValueError):
+            tetra3rs.PolynomialDistortion(2**32 - 1, 1.0, [], [])
+        with pytest.raises(ValueError):
+            tetra3rs.PolynomialDistortion(100, 1.0, [0.0], [0.0])
+
+    def test_distortion_rejects_non_finite(self):
+        with pytest.raises(ValueError):
+            tetra3rs.RadialDistortion(k1=float("nan"))
+        n = 15  # order 4
+        bad = [0.0] * n
+        bad[3] = float("inf")
+        with pytest.raises(ValueError):
+            tetra3rs.PolynomialDistortion(4, 512.0, bad, [0.0] * n)
+
+    def test_corrupt_camera_model_pickle_raises(self):
+        cam = tetra3rs.CameraModel.from_fov(10.0, 1024, 768)
+        blob = pickle.dumps(cam)
+        # Truncating the payload must give a clean exception, not a panic on
+        # a later method call.
+        with pytest.raises(Exception) as excinfo:
+            pickle.loads(blob[:-4])
+        assert "Panic" not in type(excinfo.value).__name__

--- a/python/tests/test_solve.py
+++ b/python/tests/test_solve.py
@@ -199,6 +199,23 @@ class TestSolveFromCentroids:
                 attitude_hint=[0.0, 0.0, 0.0, 0.0],
             )
 
+    def test_invalid_config_status(self, skyview_db):
+        """Non-finite matching parameters fail fast with 'invalid_config'
+        instead of burning the search to a guaranteed 'no_match'."""
+        centroids = np.array(
+            [[40.0 * i - 100.0, 25.0 * i - 60.0] for i in range(6)], dtype=np.float64
+        )
+        result = skyview_db.solve_from_centroids(
+            centroids,
+            fov_estimate_deg=10.0,
+            image_width=2048,
+            image_height=2048,
+            match_radius=float("nan"),
+        )
+        assert not result
+        assert result.status == "invalid_config"
+        assert result.solve_time_ms < 100.0
+
     def test_solve_with_numpy_array_3col(self, skyview_db):
         """Verify centroids can be passed as Nx3 numpy array (x, y, brightness)."""
         ra, dec = 83.0, -1.0

--- a/python/tetra3rs/__init__.pyi
+++ b/python/tetra3rs/__init__.pyi
@@ -395,8 +395,10 @@ class SolveFailure:
         """Why the solve produced no solution.
 
         One of ``'no_match'`` (all pattern combinations exhausted),
-        ``'timeout'`` (``solve_timeout_ms`` reached), or ``'too_few'``
-        (fewer than 4 usable centroids).
+        ``'timeout'`` (``solve_timeout_ms`` reached), ``'too_few'``
+        (fewer than 4 usable centroids), or ``'invalid_config'``
+        (degenerate camera model or non-finite matching parameters —
+        nothing was searched).
         """
         ...
 
@@ -745,8 +747,8 @@ class SolverDatabase:
         Returns:
             A SolveResult on success, or a (falsy) SolveFailure carrying the
             failure reason (``status``: ``'no_match'`` / ``'timeout'`` /
-            ``'too_few'``) and ``solve_time_ms``. Use ``if result:`` to
-            distinguish the two.
+            ``'too_few'`` / ``'invalid_config'``) and ``solve_time_ms``. Use
+            ``if result:`` to distinguish the two.
         """
         ...
 

--- a/src/aberration.rs
+++ b/src/aberration.rs
@@ -29,7 +29,10 @@ const L_RATE_DEG: f64 = 0.9856474;
 ///
 /// * `days_since_j2000` — Days since the J2000.0 epoch (2000 January 1,
 ///   12:00 TT). TT ≈ UTC + 69 s; the difference is negligible for this
-///   approximation.
+///   approximation. Must be finite (a NaN/inf input propagates into a NaN
+///   velocity vector, which the solver then treats as "no correction
+///   possible" — every aberrated star fails to match); magnitudes beyond
+///   ~1e13 days lose all angular precision in the trigonometry.
 ///
 /// # Returns
 ///

--- a/src/camera_model.rs
+++ b/src/camera_model.rs
@@ -50,11 +50,14 @@ impl CameraModel {
     ///
     /// Sets crpix to `[0, 0]`, no parity flip, no distortion.
     ///
-    /// `fov_rad` must lie in `(0, π)`; outside that range the focal length is
-    /// non-positive or infinite, which propagates NaN/negative pixel scales
-    /// through the solver (checked in debug builds).
+    /// # Panics
+    ///
+    /// Panics unless `fov_rad` lies in `(0, π)` — outside that range the focal
+    /// length is non-positive, infinite, or NaN, which silently poisons every
+    /// pixel scale downstream. (Was a debug-only check before 0.9; release
+    /// builds accepted the garbage.)
     pub fn from_fov(fov_rad: f64, image_width: u32, image_height: u32) -> Self {
-        debug_assert!(
+        assert!(
             fov_rad.is_finite() && fov_rad > 0.0 && fov_rad < std::f64::consts::PI,
             "from_fov: fov_rad must be in (0, π), got {fov_rad}"
         );
@@ -122,6 +125,38 @@ impl CameraModel {
         (dx + self.crpix[0], dy + self.crpix[1])
     }
 
+    /// Check the invariants a well-formed camera model must satisfy: finite
+    /// positive focal length, non-zero image dimensions, finite CRPIX, and a
+    /// self-consistent distortion model.
+    ///
+    /// Postcard/serde deserialization checks structure, not semantics — a
+    /// bit-flipped saved model can decode cleanly and then divide by a zero
+    /// focal length or index past a truncated coefficient vector. Called by
+    /// [`Self::load_from_file`]; call it yourself after any other untrusted
+    /// deserialization (e.g. pickle bytes).
+    pub fn validate(&self) -> crate::Result<()> {
+        use crate::Error::InvalidInput;
+        if !(self.focal_length_px.is_finite() && self.focal_length_px > 0.0) {
+            return Err(InvalidInput(format!(
+                "CameraModel: focal_length_px must be finite and > 0, got {}",
+                self.focal_length_px
+            )));
+        }
+        if self.image_width == 0 || self.image_height == 0 {
+            return Err(InvalidInput(format!(
+                "CameraModel: image dimensions must be non-zero, got {}x{}",
+                self.image_width, self.image_height
+            )));
+        }
+        if !(self.crpix[0].is_finite() && self.crpix[1].is_finite()) {
+            return Err(InvalidInput(format!(
+                "CameraModel: crpix must be finite, got [{}, {}]",
+                self.crpix[0], self.crpix[1]
+            )));
+        }
+        self.distortion.validate()
+    }
+
     /// Save the camera model to a file using postcard.
     pub fn save_to_file<P: AsRef<Path>>(&self, path: P) -> crate::Result<()> {
         let bytes = postcard::to_allocvec(self)?;
@@ -130,9 +165,15 @@ impl CameraModel {
     }
 
     /// Load a camera model from a postcard file.
+    ///
+    /// The decoded model is checked with [`Self::validate`] so a corrupt or
+    /// truncated file fails here with [`crate::Error::InvalidInput`] instead
+    /// of panicking (or silently producing NaN) on first use.
     pub fn load_from_file<P: AsRef<Path>>(path: P) -> crate::Result<Self> {
         let bytes = std::fs::read(&path)?;
-        Ok(postcard::from_bytes::<Self>(&bytes)?)
+        let model = postcard::from_bytes::<Self>(&bytes)?;
+        model.validate()?;
+        Ok(model)
     }
 }
 
@@ -292,6 +333,42 @@ mod tests {
             expected_xi,
             xi,
         );
+    }
+
+    #[test]
+    #[should_panic(expected = "fov_rad must be in (0, π)")]
+    fn test_from_fov_rejects_zero_fov() {
+        // Regression: this was a debug_assert, so release builds silently
+        // produced an infinite focal length.
+        let _ = CameraModel::from_fov(0.0, 1024, 768);
+    }
+
+    #[test]
+    fn test_validate_and_load_reject_degenerate_models() {
+        let mut cam = CameraModel::from_fov(10.0_f64.to_radians(), 1024, 768);
+        assert!(cam.validate().is_ok());
+
+        cam.focal_length_px = 0.0;
+        assert!(cam.validate().is_err());
+
+        // Regression: load_from_file used to hand back whatever decoded,
+        // deferring the failure to a divide-by-zero / OOB at first use.
+        let tmp = std::env::temp_dir().join("test_camera_model_invalid.bin");
+        std::fs::write(&tmp, postcard::to_allocvec(&cam).unwrap()).unwrap();
+        assert!(CameraModel::load_from_file(&tmp).is_err());
+        std::fs::remove_file(&tmp).ok();
+
+        cam.focal_length_px = 5000.0;
+        cam.crpix = [f64::NAN, 0.0];
+        assert!(cam.validate().is_err());
+
+        // Distortion invariants are checked through the same path: a
+        // truncated coefficient vector must fail validation, not panic later.
+        cam.crpix = [0.0, 0.0];
+        let mut poly = crate::distortion::PolynomialDistortion::zero(4, 512.0);
+        poly.a_coeffs.truncate(2);
+        cam.distortion = Distortion::Polynomial(poly);
+        assert!(cam.validate().is_err());
     }
 
     #[test]

--- a/src/catalogs/gaia.rs
+++ b/src/catalogs/gaia.rs
@@ -42,7 +42,13 @@ pub fn load_gaia_binary<P: AsRef<Path>>(path: P) -> Result<Vec<GaiaStar>> {
         )));
     }
 
-    let num_stars = u64::from_le_bytes(header[8..16].try_into().unwrap()) as usize;
+    // Convert the header's u64 count checked — `as usize` would silently
+    // truncate on a 32-bit target, loading a fraction of the claimed stars.
+    let num_stars: usize = u64::from_le_bytes(header[8..16].try_into().unwrap())
+        .try_into()
+        .map_err(|_| {
+            Error::InvalidCatalog("Gaia binary: num_stars exceeds addressable memory".into())
+        })?;
 
     let record_size = 36;
     // A corrupt/truncated header could claim a huge `num_stars`, driving a
@@ -73,6 +79,7 @@ pub fn load_gaia_binary<P: AsRef<Path>>(path: P) -> Result<Vec<GaiaStar>> {
     file.read_exact(&mut buf)?;
 
     let mut stars = Vec::with_capacity(num_stars);
+    let mut non_finite = 0usize;
     for i in 0..num_stars {
         let offset = i * record_size;
         let rec = &buf[offset..offset + record_size];
@@ -84,6 +91,20 @@ pub fn load_gaia_binary<P: AsRef<Path>>(path: P) -> Result<Vec<GaiaStar>> {
         let pmra = f32::from_le_bytes(rec[28..32].try_into().unwrap());
         let pmdec = f32::from_le_bytes(rec[32..36].try_into().unwrap());
 
+        // A NaN/inf position or magnitude would land the star in a bogus
+        // spatial-index bin (or drop it from every magnitude cut), and a
+        // non-finite proper motion poisons epoch propagation — all with no
+        // diagnostic. Skip such records and report the count instead.
+        if !(ra.is_finite()
+            && dec.is_finite()
+            && mag.is_finite()
+            && pmra.is_finite()
+            && pmdec.is_finite())
+        {
+            non_finite += 1;
+            continue;
+        }
+
         stars.push(GaiaStar {
             source_id,
             ra_deg: ra as f32,
@@ -92,6 +113,9 @@ pub fn load_gaia_binary<P: AsRef<Path>>(path: P) -> Result<Vec<GaiaStar>> {
             pmra,
             pmdec,
         });
+    }
+    if non_finite > 0 {
+        tracing::warn!("Gaia binary: skipped {non_finite} record(s) with non-finite ra/dec/mag");
     }
 
     Ok(stars)

--- a/src/catalogs/hipparcos.rs
+++ b/src/catalogs/hipparcos.rs
@@ -40,21 +40,30 @@ impl HipparcosStar {
     }
 }
 
+/// Extract a fixed-width column as `&str`, or `None` if the bytes in that
+/// range are not valid UTF-8. Slicing the record as bytes (not `&str`) keeps
+/// a multi-byte character straddling a column boundary from panicking — such
+/// a line is malformed and gets skipped like any other unparseable record.
+fn column(record: &[u8], range: std::ops::Range<usize>) -> Option<&str> {
+    std::str::from_utf8(record.get(range)?).ok()
+}
+
 /// Parse a single Hipparcos catalog record into a `HipparcosStar`.
 fn parse_hipparcos_star(record: &str) -> Option<HipparcosStar> {
+    let bytes = record.as_bytes();
     // Highest column offset the parser reads is the B−V field ending at 158.
-    if record.len() < 158 {
+    if bytes.len() < 158 {
         return None;
     }
 
     Some(HipparcosStar {
-        hip: record[0..6].trim().parse().ok()?,
-        ra_rad: record[15..28].trim().parse().ok()?,
-        dec_rad: record[29..42].trim().parse().ok()?,
-        pm_ra: record[51..59].trim().parse().ok()?,
-        pm_dec: record[60..68].trim().parse().ok()?,
-        hpmag: record[129..136].trim().parse().ok()?,
-        b_v: record[152..158].trim().parse().ok()?,
+        hip: column(bytes, 0..6)?.trim().parse().ok()?,
+        ra_rad: column(bytes, 15..28)?.trim().parse().ok()?,
+        dec_rad: column(bytes, 29..42)?.trim().parse().ok()?,
+        pm_ra: column(bytes, 51..59)?.trim().parse().ok()?,
+        pm_dec: column(bytes, 60..68)?.trim().parse().ok()?,
+        hpmag: column(bytes, 129..136)?.trim().parse().ok()?,
+        b_v: column(bytes, 152..158)?.trim().parse().ok()?,
     })
 }
 
@@ -86,6 +95,19 @@ pub fn load_hipparcos_catalog_from_file<P: AsRef<std::path::Path>>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn multibyte_utf8_line_is_skipped_not_panicked() {
+        // Regression: `&str` byte-range slicing panicked when a multi-byte
+        // character straddled a fixed-width column boundary (e.g. at byte 5).
+        let mut line = String::from("  12é"); // 'é' spans bytes 4..6 — across the 0..6 boundary
+        line.push_str(&" ".repeat(160));
+        assert!(parse_hipparcos_star(&line).is_none());
+
+        // A fully multi-byte line long enough to pass the length gate.
+        let junk = "é".repeat(100);
+        assert!(parse_hipparcos_star(&junk).is_none());
+    }
 
     #[test]
     #[ignore]

--- a/src/centroid_extraction/ccl.rs
+++ b/src/centroid_extraction/ccl.rs
@@ -49,6 +49,17 @@ pub(super) fn extract_from_gray(
         )));
     }
 
+    // The Gaussian kernel spans 2·⌈3σ⌉+1 taps, so an absurd σ is a
+    // multi-gigabyte allocation / effective hang, not a blur. 64 px covers
+    // any plausible star PSF with two orders of magnitude to spare.
+    const MAX_MATCHED_FILTER_SIGMA: f32 = 64.0;
+    if let Some(s) = config.matched_filter_sigma {
+        if s.is_finite() && s > MAX_MATCHED_FILTER_SIGMA {
+            return Err(Error::InvalidInput(format!(
+                "matched_filter_sigma must be <= {MAX_MATCHED_FILTER_SIGMA} px, got {s}"
+            )));
+        }
+    }
     let filter_sigma = config
         .matched_filter_sigma
         .filter(|s| s.is_finite() && *s > 0.0);

--- a/src/centroid_extraction/mod.rs
+++ b/src/centroid_extraction/mod.rs
@@ -326,7 +326,14 @@ fn sort_and_truncate_by_mass(centroids: &mut Vec<Centroid>, max_centroids: Optio
 
 /// Validate that a raw pixel buffer matches the claimed dimensions.
 fn check_pixel_len(len: usize, width: u32, height: u32) -> Result<()> {
-    let expected = (width as usize) * (height as usize);
+    // Checked multiply: on a 32-bit target `width * height` can wrap in
+    // `usize` (e.g. 65536×65536 → 0), letting an undersized buffer through to
+    // panic on indexing later. No real buffer can reach a wrapping size.
+    let expected = (width as usize)
+        .checked_mul(height as usize)
+        .ok_or_else(|| {
+            Error::InvalidInput(format!("image dimensions {width}x{height} overflow usize"))
+        })?;
     if len != expected {
         return Err(Error::InvalidInput(format!(
             "Pixel data length ({len}) does not match width*height ({width}x{height}={expected})",

--- a/src/distortion/calibrate.rs
+++ b/src/distortion/calibrate.rs
@@ -140,16 +140,19 @@ pub fn calibrate_camera(
     image_height: u32,
     config: &CalibrateConfig,
 ) -> crate::Result<CalibrateResult> {
-    assert_eq!(
-        solve_results.len(),
-        centroids.len(),
-        "solve_results and centroids must have the same length"
-    );
+    if solve_results.len() != centroids.len() {
+        return Err(crate::Error::InvalidInput(format!(
+            "calibrate_camera: solve_results ({}) and centroids ({}) must have the same length",
+            solve_results.len(),
+            centroids.len()
+        )));
+    }
     if let DistortionModelType::Polynomial { order } = config.model {
-        assert!(
-            (2..=6).contains(&order),
-            "polynomial order must be in [2, 6]"
-        );
+        if !(2..=6).contains(&order) {
+            return Err(crate::Error::InvalidInput(format!(
+                "calibrate_camera: polynomial order must be in [2, 6], got {order}"
+            )));
+        }
     }
 
     // Count valid (successful) solves. With none, there is no attitude/FOV to
@@ -211,7 +214,11 @@ fn extract_crpix(distortion: Distortion) -> ([f64; 2], Distortion) {
             let new_poly = PolynomialDistortion::new(poly.order, poly.scale, a, b);
             ([crpix_x, crpix_y], Distortion::Polynomial(new_poly))
         }
-        other => ([0.0, 0.0], other),
+        // Matched explicitly (no catch-all) so a future variant carrying its
+        // own optical-center offset is caught by the compiler here, like the
+        // multi-image path's match does.
+        Distortion::None => ([0.0, 0.0], Distortion::None),
+        Distortion::Radial(r) => ([0.0, 0.0], Distortion::Radial(r)),
     }
 }
 
@@ -240,6 +247,18 @@ fn single_image_calibrate(
             fit_radial_distortion(solve_results, centroids, database, image_width, &fit_config)
         }
     };
+
+    // A fitter that had too few matched points returns its `no_fit` sentinel
+    // (identity model). Wrapping that in `Ok` would hand back a perfect-looking
+    // fabricated calibration (RMSE 0, no distortion) — exactly what the
+    // documented error contract promises to reject; the multi-image path
+    // enforces the same via its RMSE sentinel.
+    if fit_result.model.is_none() {
+        return Err(crate::Error::InvalidInput(format!(
+            "calibrate_camera: too few matched points ({}) for a {:?} distortion fit",
+            fit_result.n_inliers, config.model
+        )));
+    }
 
     // FOV and parity come from the (caller-guaranteed) successful solve.
     let first_solution = solve_results

--- a/src/distortion/fit.rs
+++ b/src/distortion/fit.rs
@@ -131,6 +131,12 @@ pub(super) struct MatchedPoint {
 /// most photographic / computer-vision lens calibrations; for cameras with
 /// significant tangential / decentering distortion (e.g. TESS), prefer
 /// [`fit_polynomial_distortion`] which has more parameters to absorb it.
+///
+/// # Panics
+///
+/// Panics when `solve_results` and `centroids` differ in length.
+/// [`crate::calibrate_camera`] validates this (returning an error) before
+/// delegating here.
 pub fn fit_radial_distortion(
     solve_results: &[&SolveResult],
     centroids: &[&[Centroid]],
@@ -762,6 +768,12 @@ pub(super) fn fit_polynomial_sigma_clip(
 /// - order 2: 6 terms per axis (12 total) — offset + linear + quadratic
 /// - order 3: 10 terms per axis (20 total) — + cubic
 /// - order 4: 15 terms per axis (30 total) — + quartic (recommended for TESS)
+///
+/// # Panics
+///
+/// Panics when `solve_results` and `centroids` differ in length or `order` is
+/// outside `[2, 6]`. [`crate::calibrate_camera`] validates both (returning an
+/// error) before delegating here.
 /// - order 5: 21 terms per axis (42 total) — + quintic
 ///
 /// Order-0 terms absorb optical center offset; order-1 terms absorb residual

--- a/src/distortion/mod.rs
+++ b/src/distortion/mod.rs
@@ -30,7 +30,7 @@ pub(crate) mod polynomial;
 pub(crate) mod radial;
 
 pub use calibrate::{calibrate_camera, CalibrateConfig, CalibrateResult, DistortionModelType};
-pub use polynomial::{num_coeffs, PolynomialDistortion};
+pub use polynomial::{num_coeffs, PolynomialDistortion, MAX_POLY_ORDER};
 pub use radial::RadialDistortion;
 
 /// Lens distortion model.
@@ -77,5 +77,16 @@ impl Distortion {
     /// Returns `true` if this is `Distortion::None`.
     pub fn is_none(&self) -> bool {
         matches!(self, Distortion::None)
+    }
+
+    /// Validate the inner model's invariants (see
+    /// [`PolynomialDistortion::validate`] / [`RadialDistortion::validate`]).
+    /// Call after deserializing from an untrusted source.
+    pub fn validate(&self) -> crate::Result<()> {
+        match self {
+            Distortion::None => Ok(()),
+            Distortion::Radial(r) => r.validate(),
+            Distortion::Polynomial(p) => p.validate(),
+        }
     }
 }

--- a/src/distortion/polynomial.rs
+++ b/src/distortion/polynomial.rs
@@ -73,6 +73,12 @@ pub struct PolynomialDistortion {
     pub bp_coeffs: Vec<f64>,
 }
 
+/// Largest polynomial order accepted by [`PolynomialDistortion::new`] /
+/// [`PolynomialDistortion::zero`] and by [`PolynomialDistortion::validate`].
+/// SIP fits in practice use order 2–6; this bound exists so an absurd order
+/// can't drive coefficient-count arithmetic or allocations off a cliff.
+pub const MAX_POLY_ORDER: u32 = 12;
+
 impl PolynomialDistortion {
     /// Create a new polynomial distortion model from the forward coefficients.
     ///
@@ -80,7 +86,16 @@ impl PolynomialDistortion {
     /// elements. The legacy inverse (`ap`/`bp`) coefficients are zero-filled —
     /// this crate inverts numerically (Newton) rather than storing an inverse
     /// polynomial; the fields persist only for binary-format compatibility.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `order > MAX_POLY_ORDER` or when a coefficient vector's
+    /// length is not `num_coeffs(order)`.
     pub fn new(order: u32, scale: f64, a_coeffs: Vec<f64>, b_coeffs: Vec<f64>) -> Self {
+        assert!(
+            order <= MAX_POLY_ORDER,
+            "polynomial order must be <= {MAX_POLY_ORDER}, got {order}"
+        );
         let n = num_coeffs(order);
         assert_eq!(a_coeffs.len(), n, "a_coeffs length mismatch");
         assert_eq!(b_coeffs.len(), n, "b_coeffs length mismatch");
@@ -95,7 +110,15 @@ impl PolynomialDistortion {
     }
 
     /// Create a zero (identity) polynomial distortion model.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `order > MAX_POLY_ORDER`.
     pub fn zero(order: u32, scale: f64) -> Self {
+        assert!(
+            order <= MAX_POLY_ORDER,
+            "polynomial order must be <= {MAX_POLY_ORDER}, got {order}"
+        );
         let n = num_coeffs(order);
         Self {
             order,
@@ -161,15 +184,13 @@ impl PolynomialDistortion {
             let j21 = db_du;
             let j22 = 1.0 + db_dv;
             let det = j11 * j22 - j12 * j21;
-            // Singular Jacobian indicates near-degenerate distortion at this
-            // point. We've never observed this in practice — for any sensible
-            // lens distortion the Jacobian is dominated by the identity. If
-            // it ever fires, the latest iterate is still the best estimate.
-            debug_assert!(
-                det.abs() > 1e-15,
-                "singular Jacobian in undistort Newton step"
-            );
-            if det.abs() < 1e-15 {
+            // Singular (or NaN, from non-finite input) Jacobian indicates
+            // degenerate distortion at this point; for any sensible lens the
+            // Jacobian is dominated by the identity. Bail with the latest
+            // iterate — it is still the best estimate. (Deliberately not an
+            // assert: NaN centroids are legal caller input and are filtered
+            // downstream by the solver's finiteness checks.)
+            if !det.is_finite() || det.abs() < 1e-15 {
                 break;
             }
             let inv_det = 1.0 / det;
@@ -180,6 +201,46 @@ impl PolynomialDistortion {
         }
 
         (x, y)
+    }
+
+    /// Check the cross-field invariants that construction normally enforces
+    /// but deserialization (and direct field access — the fields are `pub`)
+    /// can bypass: bounded order, coefficient-vector lengths matching
+    /// `num_coeffs(order)`, and finite scale/coefficients.
+    ///
+    /// Call this after loading a model from an untrusted source (saved file,
+    /// pickle bytes): `distort` / `undistort` index the coefficient vectors
+    /// by `order` and panic out-of-bounds when the two disagree.
+    pub fn validate(&self) -> crate::Result<()> {
+        use crate::Error::InvalidInput;
+        if self.order > MAX_POLY_ORDER {
+            return Err(InvalidInput(format!(
+                "PolynomialDistortion: order must be <= {MAX_POLY_ORDER}, got {}",
+                self.order
+            )));
+        }
+        let n = num_coeffs(self.order);
+        for (name, coeffs) in [("a_coeffs", &self.a_coeffs), ("b_coeffs", &self.b_coeffs)] {
+            if coeffs.len() != n {
+                return Err(InvalidInput(format!(
+                    "PolynomialDistortion: {name} has {} coefficients, order {} requires {n}",
+                    coeffs.len(),
+                    self.order
+                )));
+            }
+            if coeffs.iter().any(|c| !c.is_finite()) {
+                return Err(InvalidInput(format!(
+                    "PolynomialDistortion: {name} contains a non-finite coefficient"
+                )));
+            }
+        }
+        if !(self.scale.is_finite() && self.scale > 0.0) {
+            return Err(InvalidInput(format!(
+                "PolynomialDistortion: scale must be finite and > 0, got {}",
+                self.scale
+            )));
+        }
+        Ok(())
     }
 }
 
@@ -195,8 +256,13 @@ impl PolynomialDistortion {
 ///   etc.
 ///
 /// Total = (order+1)(order+2)/2.
+///
+/// Computed in `u128` (saturating at `usize::MAX`) so an absurd `order` near
+/// `u32::MAX` cannot wrap to a small count — a wrapped count would let
+/// `eval_poly` run past the coefficient vector.
 pub fn num_coeffs(order: u32) -> usize {
-    ((order + 1) * (order + 2) / 2) as usize
+    let o = order as u128;
+    usize::try_from((o + 1) * (o + 2) / 2).unwrap_or(usize::MAX)
 }
 
 /// Map (p, q) with 0 ≤ p+q ≤ order to a flat index.
@@ -329,6 +395,49 @@ mod tests {
                 (0, 3)
             ]
         );
+    }
+
+    #[test]
+    fn test_num_coeffs_no_overflow() {
+        // Regression: u32 arithmetic wrapped for huge orders, letting an
+        // absurd `order` pair with tiny coefficient vectors and index OOB.
+        // (o+1)(o+2)/2 at o = 2³²−1 is 2⁶³ + 2³¹.
+        assert_eq!(num_coeffs(u32::MAX), (1u64 << 63) as usize + (1 << 31));
+    }
+
+    #[test]
+    fn test_validate_catches_inconsistent_fields() {
+        let good = PolynomialDistortion::zero(4, 1024.0);
+        assert!(good.validate().is_ok());
+
+        // Coefficient count disagreeing with order (constructible because the
+        // fields are pub, and decodable from tampered pickle/file bytes).
+        let mut bad = good.clone();
+        bad.a_coeffs.truncate(3);
+        assert!(bad.validate().is_err());
+
+        let mut bad = good.clone();
+        bad.order = MAX_POLY_ORDER + 1;
+        assert!(bad.validate().is_err());
+
+        let mut bad = good.clone();
+        bad.scale = 0.0;
+        assert!(bad.validate().is_err());
+
+        let mut bad = good.clone();
+        bad.b_coeffs[2] = f64::NAN;
+        assert!(bad.validate().is_err());
+    }
+
+    #[test]
+    fn test_undistort_nan_input_returns_without_panic() {
+        // Regression: a debug_assert on the Newton Jacobian determinant fired
+        // for NaN inputs (legal caller data — the solver filters non-finite
+        // centroids downstream).
+        let d = PolynomialDistortion::zero(4, 1024.0);
+        let (x, y) = d.undistort(f64::NAN, 100.0);
+        assert!(x.is_nan());
+        assert!(y.is_finite() || y.is_nan());
     }
 
     #[test]

--- a/src/distortion/radial.rs
+++ b/src/distortion/radial.rs
@@ -117,6 +117,22 @@ impl RadialDistortion {
         }
     }
 
+    /// Check that every coefficient and the center are finite. Call after
+    /// loading a model from an untrusted source (saved file, pickle bytes) —
+    /// a NaN coefficient silently poisons every undistorted coordinate.
+    pub fn validate(&self) -> crate::Result<()> {
+        let finite = [self.k1, self.k2, self.k3, self.p1, self.p2]
+            .iter()
+            .all(|c| c.is_finite())
+            && self.center.iter().all(|c| c.is_finite());
+        if !finite {
+            return Err(crate::Error::InvalidInput(
+                "RadialDistortion: coefficients and center must be finite".into(),
+            ));
+        }
+        Ok(())
+    }
+
     /// Forward distortion: ideal → distorted.
     ///
     /// Given ideal (pinhole) pixel coordinates `(x, y)`, returns the

--- a/src/solver/database.rs
+++ b/src/solver/database.rs
@@ -22,6 +22,13 @@ use super::{DatabaseProperties, GenerateDatabaseConfig, PatternEntry, SolverData
 
 // ── Sky geometry utilities ──────────────────────────────────────────────────
 
+/// Hard ceiling on lattice points per FOV scale during generation. The count
+/// scales as `oversampling / fov²`, so a tiny-but-valid `min_fov_deg` (e.g.
+/// 0.1° at the default oversampling of 100 → ~5×10⁸ points ≈ 6 GB) would
+/// otherwise exhaust memory with no diagnostic. 10⁸ points (1.2 GB) is far
+/// beyond any published tetra3-style database.
+const MAX_LATTICE_POINTS: usize = 100_000_000;
+
 /// Approximate number of FOV-sized fields needed to tile the full sky.
 fn num_fields_for_sky(fov_rad: f32) -> usize {
     // Solid angle of a cone with half-angle fov/2: 2π(1 − cos(fov/2))
@@ -253,8 +260,16 @@ impl SolverDatabase {
 
             // ── Distribute lattice fields and generate patterns ──
             let fov_angle = pattern_fov / 2.0;
-            let n_fields =
-                num_fields_for_sky(pattern_fov) * config.lattice_field_oversampling as usize;
+            let n_fields = num_fields_for_sky(pattern_fov)
+                .saturating_mul(config.lattice_field_oversampling as usize);
+            if n_fields > MAX_LATTICE_POINTS {
+                return Err(crate::Error::InvalidInput(format!(
+                    "lattice would need {n_fields} field centers at FOV {:.3}° \
+                     (limit {MAX_LATTICE_POINTS}); raise min_fov_deg or lower \
+                     lattice_field_oversampling",
+                    pattern_fov.to_degrees()
+                )));
+            }
 
             let lattice_points = fibonacci_sphere_lattice(n_fields);
             let mut total_added = 0usize;
@@ -412,27 +427,118 @@ fn compute_magnitude_cutoff(stars: &[Star], min_fov: f32, verification_stars_per
 
 impl SolverDatabase {
     /// Serialize the database to bytes using postcard.
-    pub fn to_bytes(&self) -> Vec<u8> {
-        postcard::to_allocvec(self).expect("postcard serialization failed")
+    pub fn to_bytes(&self) -> crate::Result<Vec<u8>> {
+        Ok(postcard::to_allocvec(self)?)
     }
 
     /// Save the database to a file using postcard.
     pub fn save_to_file(&self, path: &str) -> crate::Result<()> {
-        let bytes = self.to_bytes();
+        let bytes = self.to_bytes()?;
         std::fs::write(path, &bytes)?;
         info!("Saved database to {} ({} bytes)", path, bytes.len());
         Ok(())
     }
 
     /// Load a database from a postcard file.
+    ///
+    /// The decoded database is checked with [`Self::validate`], so a corrupt,
+    /// truncated, or tampered file fails here with a descriptive
+    /// [`crate::Error::InvalidInput`] instead of panicking mid-solve.
     pub fn load_from_file(path: &str) -> crate::Result<Self> {
         let bytes = std::fs::read(path)?;
         let db = postcard::from_bytes::<Self>(&bytes)?;
+        db.validate()?;
         info!(
             "Loaded database: {} stars, {} patterns",
             db.star_catalog.len(),
             db.props.num_patterns
         );
         Ok(db)
+    }
+
+    /// Check the cross-field invariants the solver relies on but postcard
+    /// deserialization cannot: every structure decodes independently, so a
+    /// file that parses cleanly can still carry pattern entries indexing past
+    /// the star table, a spatial index inconsistent with its stars, or
+    /// properties that blow up the key-enumeration bounds. Each of those is a
+    /// deferred panic (or memory blow-up) on the first solve.
+    ///
+    /// Called by [`Self::load_from_file`]; call it yourself after decoding
+    /// database bytes from any other untrusted source (e.g. pickle).
+    pub fn validate(&self) -> crate::Result<()> {
+        use crate::Error::InvalidInput;
+        self.star_catalog.validate()?;
+
+        let n_stars = self.star_catalog.len();
+        if self.star_vectors.len() != n_stars || self.star_catalog_ids.len() != n_stars {
+            return Err(InvalidInput(format!(
+                "SolverDatabase: star_vectors ({}) / star_catalog_ids ({}) must both match \
+                 the star catalog ({n_stars} stars)",
+                self.star_vectors.len(),
+                self.star_catalog_ids.len()
+            )));
+        }
+
+        let p = &self.props;
+        if !(p.pattern_max_error.is_finite()
+            && p.pattern_max_error > 0.0
+            && p.pattern_max_error <= 0.25)
+        {
+            return Err(InvalidInput(format!(
+                "SolverDatabase: props.pattern_max_error must be in (0, 0.25], got {}",
+                p.pattern_max_error
+            )));
+        }
+        // Generation always derives bins from the error tolerance; a file
+        // claiming a different (huge) bin count inflates the solver's 5-D
+        // candidate-key enumeration without bound.
+        let expected_bins = (0.25 / p.pattern_max_error).round() as u32;
+        if p.pattern_bins != expected_bins {
+            return Err(InvalidInput(format!(
+                "SolverDatabase: props.pattern_bins ({}) inconsistent with \
+                 pattern_max_error {} (expected {expected_bins})",
+                p.pattern_bins, p.pattern_max_error
+            )));
+        }
+        let fov_ok = p.max_fov_rad.is_finite()
+            && p.max_fov_rad > 0.0
+            && p.max_fov_rad < std::f32::consts::PI
+            && p.min_fov_rad.is_finite()
+            && p.min_fov_rad > 0.0
+            && p.min_fov_rad <= p.max_fov_rad;
+        if !fov_ok {
+            return Err(InvalidInput(format!(
+                "SolverDatabase: props FOV range [{}, {}] rad must be finite, positive, \
+                 ordered, and below π",
+                p.min_fov_rad, p.max_fov_rad
+            )));
+        }
+        if p.verification_stars_per_fov == 0 {
+            return Err(InvalidInput(
+                "SolverDatabase: props.verification_stars_per_fov must be >= 1".into(),
+            ));
+        }
+        if p.num_patterns as usize > self.pattern_catalog.len() {
+            return Err(InvalidInput(format!(
+                "SolverDatabase: props.num_patterns ({}) exceeds the pattern table size ({})",
+                p.num_patterns,
+                self.pattern_catalog.len()
+            )));
+        }
+
+        // Every non-empty pattern entry is indexed straight into star_vectors
+        // during hash probing — before any filter can reject it.
+        for entry in &self.pattern_catalog.entries {
+            if entry.is_empty() {
+                continue;
+            }
+            if entry.star_indices.iter().any(|&i| i as usize >= n_stars) {
+                return Err(InvalidInput(format!(
+                    "SolverDatabase: pattern entry references star index past the \
+                     {n_stars}-star table"
+                )));
+            }
+        }
+        Ok(())
     }
 }

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -183,6 +183,14 @@ pub enum SolveStatus {
     Timeout,
     /// Too few centroids were provided to form a pattern.
     TooFew,
+    /// The [`SolveConfig`] failed validation (degenerate camera model or
+    /// non-finite matching parameters) — nothing was searched. See
+    /// [`SolveConfig::validate`] for the exact rules. Returned immediately,
+    /// so `solve_time_ms` is ~0.
+    ///
+    /// (Appended after the 0.9 variants, so previously serialized statuses
+    /// keep their postcard wire values.)
+    InvalidConfig,
 }
 
 /// A failed plate-solve attempt: why it failed and how long it took.
@@ -567,6 +575,77 @@ impl SolveConfig {
             0.0
         }
     }
+
+    /// Check that this configuration can produce a meaningful solve.
+    ///
+    /// `solve_from_centroids` runs this first and returns
+    /// [`SolveStatus::InvalidConfig`] on failure (previously such configs
+    /// only logged a warning and burned the full search to a guaranteed
+    /// `NoMatch`). Rules:
+    ///
+    /// - [`camera_model`](Self::camera_model) passes
+    ///   [`CameraModel::validate`] (finite positive focal length, non-zero
+    ///   dimensions, finite CRPIX, consistent distortion) — the
+    ///   `SolveConfig::default()` placeholder model fails this.
+    /// - [`match_radius`](Self::match_radius) and
+    ///   [`match_threshold`](Self::match_threshold) are finite and positive
+    ///   (NaN silently disables all matching / rejects every candidate).
+    /// - [`fov_max_error_rad`](Self::fov_max_error_rad), if set, is finite
+    ///   and non-negative (`0.0` means "no sweep beyond the estimate").
+    /// - [`match_max_error`](Self::match_max_error), if set, is finite and
+    ///   positive.
+    /// - [`observer_velocity_km_s`](Self::observer_velocity_km_s), if set,
+    ///   has finite components.
+    /// - [`hint_uncertainty_rad`](Self::hint_uncertainty_rad) is finite and
+    ///   positive — checked only when an
+    ///   [`attitude_hint`](Self::attitude_hint) is set (the field is inert
+    ///   otherwise).
+    pub fn validate(&self) -> crate::Result<()> {
+        use crate::Error::InvalidInput;
+        self.camera_model.validate()?;
+        if !(self.match_radius.is_finite() && self.match_radius > 0.0) {
+            return Err(InvalidInput(format!(
+                "match_radius must be finite and > 0, got {}",
+                self.match_radius
+            )));
+        }
+        if !(self.match_threshold.is_finite() && self.match_threshold > 0.0) {
+            return Err(InvalidInput(format!(
+                "match_threshold must be finite and > 0, got {}",
+                self.match_threshold
+            )));
+        }
+        if let Some(e) = self.fov_max_error_rad {
+            if !(e.is_finite() && e >= 0.0) {
+                return Err(InvalidInput(format!(
+                    "fov_max_error_rad must be finite and >= 0, got {e}"
+                )));
+            }
+        }
+        if let Some(e) = self.match_max_error {
+            if !(e.is_finite() && e > 0.0) {
+                return Err(InvalidInput(format!(
+                    "match_max_error must be finite and > 0, got {e}"
+                )));
+            }
+        }
+        if let Some(v) = self.observer_velocity_km_s {
+            if !v.iter().all(|c| c.is_finite()) {
+                return Err(InvalidInput(format!(
+                    "observer_velocity_km_s components must be finite, got {v:?}"
+                )));
+            }
+        }
+        if self.attitude_hint.is_some()
+            && !(self.hint_uncertainty_rad.is_finite() && self.hint_uncertainty_rad > 0.0)
+        {
+            return Err(InvalidInput(format!(
+                "hint_uncertainty_rad must be finite and > 0, got {}",
+                self.hint_uncertainty_rad
+            )));
+        }
+        Ok(())
+    }
 }
 
 // ── Solve result ────────────────────────────────────────────────────────────
@@ -713,5 +792,41 @@ mod tests {
         bad(|c| c.catalog_nside = 0);
         bad(|c| c.max_fov_deg = 0.0);
         bad(|c| c.min_fov_deg = Some(40.0)); // > max_fov_deg (30)
+    }
+
+    #[test]
+    fn solve_config_validate() {
+        let good = SolveConfig::new(10.0_f32.to_radians(), 1024, 768);
+        assert!(good.validate().is_ok());
+
+        // The unconfigured Default placeholder camera must fail.
+        assert!(SolveConfig::default().validate().is_err());
+
+        let bad = |f: fn(&mut SolveConfig)| {
+            let mut c = SolveConfig::new(10.0_f32.to_radians(), 1024, 768);
+            f(&mut c);
+            assert!(c.validate().is_err());
+        };
+        bad(|c| c.match_radius = f32::NAN); // silently disables all matching
+        bad(|c| c.match_radius = 0.0);
+        bad(|c| c.match_threshold = f64::NAN); // rejects every candidate
+        bad(|c| c.match_threshold = -1e-5);
+        bad(|c| c.fov_max_error_rad = Some(f32::NAN));
+        bad(|c| c.fov_max_error_rad = Some(f32::INFINITY));
+        bad(|c| c.match_max_error = Some(f32::NAN));
+        bad(|c| c.observer_velocity_km_s = Some([f64::NAN, 0.0, 0.0]));
+        bad(|c| {
+            c.attitude_hint = Some(Quaternion::identity());
+            c.hint_uncertainty_rad = f32::NAN;
+        });
+
+        // hint_uncertainty is inert (and unchecked) without a hint.
+        let mut c = SolveConfig::new(10.0_f32.to_radians(), 1024, 768);
+        c.hint_uncertainty_rad = f32::NAN;
+        assert!(c.validate().is_ok());
+        // Zero fov_max_error means "no sweep" — allowed.
+        c.hint_uncertainty_rad = 1.0;
+        c.fov_max_error_rad = Some(0.0);
+        assert!(c.validate().is_ok());
     }
 }

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -344,8 +344,21 @@ impl GenerateDatabaseConfig {
                 "verification_stars_per_fov must be >= 1".into(),
             ));
         }
-        if self.catalog_nside == 0 {
-            return Err(InvalidInput("catalog_nside must be >= 1".into()));
+        if self.catalog_nside == 0 || self.catalog_nside > crate::starcatalog::MAX_NSIDE {
+            return Err(InvalidInput(format!(
+                "catalog_nside must be in [1, {}], got {}",
+                crate::starcatalog::MAX_NSIDE,
+                self.catalog_nside
+            )));
+        }
+        // The epoch multiplies proper motions (star.ra + μ·Δt); NaN/absurd
+        // years silently produce NaN star positions and a useless database.
+        if let Some(year) = self.epoch_proper_motion_year {
+            if !(year.is_finite() && (1000.0..=3000.0).contains(&year)) {
+                return Err(InvalidInput(format!(
+                    "epoch_proper_motion_year must be a plausible year in [1000, 3000], got {year}"
+                )));
+            }
         }
         Ok(())
     }

--- a/src/solver/solve.rs
+++ b/src/solver/solve.rs
@@ -90,35 +90,16 @@ impl SolverDatabase {
     ) -> SolveResult {
         let t0 = Instant::now();
 
-        // The `SolveConfig::default()` camera model is a placeholder with a zero
-        // image size / focal length; a config left at those defaults yields a
-        // degenerate FOV and silently NoMatches. Warn loudly so the cause is
-        // visible rather than mysterious.
+        // A config that cannot produce a meaningful solve — the
+        // `SolveConfig::default()` placeholder camera model (zero image size),
+        // NaN match parameters that silently disable all matching, etc. —
+        // fails fast with `InvalidConfig` instead of burning the full search
+        // to a guaranteed NoMatch.
+        if let Err(e) = config.validate() {
+            warn!("solve_from_centroids: {e}");
+            return failure(SolveStatus::InvalidConfig, t0);
+        }
         let cam = &config.camera_model;
-        let focal_ok = cam.focal_length_px.is_finite() && cam.focal_length_px > 0.0;
-        if cam.image_width == 0 || cam.image_height == 0 || !focal_ok {
-            warn!(
-                "camera model appears unconfigured (image {}x{}, focal_length_px {}); \
-                 solve will not match — build SolveConfig via new()/with_camera_model()",
-                cam.image_width, cam.image_height, cam.focal_length_px
-            );
-        }
-        // Same spirit for the match parameters: a NaN/non-positive match_radius
-        // makes every `d² <= r²` comparison false (silently disabling all
-        // matching), and a NaN match_threshold rejects every candidate. Warn so
-        // a guaranteed-NoMatch config is diagnosable.
-        if !(config.match_radius.is_finite() && config.match_radius > 0.0) {
-            warn!(
-                "match_radius {} is not a positive finite fraction; no star can match",
-                config.match_radius
-            );
-        }
-        if !(config.match_threshold.is_finite() && config.match_threshold > 0.0) {
-            warn!(
-                "match_threshold {} is not a positive finite probability; no candidate can pass",
-                config.match_threshold
-            );
-        }
 
         // ── Aberration correction: build corrected catalog vectors if velocity is set ──
         let star_vecs: Cow<[[f32; 3]]> = match config.observer_velocity_km_s {

--- a/src/solver/solve.rs
+++ b/src/solver/solve.rs
@@ -605,11 +605,8 @@ impl SolverDatabase {
                     // Determine parity from the rotation determinant.
                     // centroid_vectors is never mutated; when parity is needed we use
                     // a lazily-created x-flipped copy for verification matching.
-                    let parity_flip;
-                    let working_vectors: &[[f32; 3]];
-                    if rotation_matrix.det() < 0.0 {
+                    let parity_flip = if rotation_matrix.det() < 0.0 {
                         // Wrong parity (e.g. FITS image with CDELT1 < 0).
-                        parity_flip = true;
                         // Derive the parity-flipped rotation WITHOUT a second SVD.
                         //
                         // Flipping the x-component of every image vector is
@@ -631,10 +628,11 @@ impl SolverDatabase {
                         rotation_matrix[(0, 0)] = -rotation_matrix[(0, 0)];
                         rotation_matrix[(0, 1)] = -rotation_matrix[(0, 1)];
                         rotation_matrix[(0, 2)] = -rotation_matrix[(0, 2)];
+                        true
                     } else {
-                        parity_flip = false;
-                    }
-                    if rebuild {
+                        false
+                    };
+                    let working_vectors: &[[f32; 3]] = if rebuild {
                         // Rebuild the full verification set at the measured
                         // scale (parity applied directly via the x-sign).
                         let sign = if parity_flip { -1.0f32 } else { 1.0 };
@@ -644,18 +642,18 @@ impl SolverDatabase {
                                 .iter()
                                 .map(|&i| unit_vector_from_pixels(&centroids[i], ps_meas, sign)),
                         );
-                        working_vectors = &rebuilt_vectors;
+                        &rebuilt_vectors
                     } else if parity_flip {
                         // Lazily create flipped centroid vectors for matching
-                        working_vectors = flipped_vectors.get_or_insert_with(|| {
+                        flipped_vectors.get_or_insert_with(|| {
                             centroid_vectors
                                 .iter()
                                 .map(|v| [-v[0], v[1], v[2]])
                                 .collect()
-                        });
+                        })
                     } else {
-                        working_vectors = &centroid_vectors;
-                    }
+                        &centroid_vectors
+                    };
 
                     // ── Verify by matching nearby catalog stars ──
                     // The pattern stars that fall inside the tested

--- a/src/solver/solve.rs
+++ b/src/solver/solve.rs
@@ -103,6 +103,22 @@ impl SolverDatabase {
                 cam.image_width, cam.image_height, cam.focal_length_px
             );
         }
+        // Same spirit for the match parameters: a NaN/non-positive match_radius
+        // makes every `d² <= r²` comparison false (silently disabling all
+        // matching), and a NaN match_threshold rejects every candidate. Warn so
+        // a guaranteed-NoMatch config is diagnosable.
+        if !(config.match_radius.is_finite() && config.match_radius > 0.0) {
+            warn!(
+                "match_radius {} is not a positive finite fraction; no star can match",
+                config.match_radius
+            );
+        }
+        if !(config.match_threshold.is_finite() && config.match_threshold > 0.0) {
+            warn!(
+                "match_threshold {} is not a positive finite probability; no candidate can pass",
+                config.match_threshold
+            );
+        }
 
         // ── Aberration correction: build corrected catalog vectors if velocity is set ──
         let star_vecs: Cow<[[f32; 3]]> = match config.observer_velocity_km_s {
@@ -531,6 +547,16 @@ impl SolverDatabase {
 
                     // Refine FOV estimate from this match
                     let fov = cat_largest_edge / image_largest_edge * fov_estimate;
+                    // With `fov_max_error_rad: None` (the default) nothing above
+                    // bounds this ratio, and a tight image quad matching a wide
+                    // catalog pattern can imply a FOV past π — where tan(fov/2)
+                    // flips sign and the verification geometry (pixel scale,
+                    // density region) turns to nonsense. Such a candidate can
+                    // only waste refinement work or weaken the statistical
+                    // gate, never be right; skip it.
+                    if !(fov.is_finite() && fov > 0.0 && fov < std::f32::consts::PI) {
+                        continue;
+                    }
 
                     // ── Rebuild vectors at the measured scale when the sweep
                     // value is meaningfully off ──
@@ -1133,6 +1159,11 @@ fn build_fov_sweep(
 
     if let Some(max_error) = fov_max_error {
         if max_error > 0.0 {
+            // FOV values at or beyond π are geometrically meaningless, so an
+            // infinite/huge max_error (which would otherwise stall the
+            // `offset += step` accumulation below into an unbounded loop)
+            // clamps to the widest sweep that can matter.
+            let max_error = max_error.min(std::f32::consts::PI);
             // Half-diagonal angle at the estimated FOV (fov is width-referenced).
             let theta_hd = ((fov_estimate as f64 / 2.0).tan() * diag_factor as f64).atan();
             // Second-order ratio-drift coefficient; guarded so a degenerate
@@ -1147,7 +1178,12 @@ fn build_fov_sweep(
                 if fov_estimate - offset > 0.0 {
                     values.push(fov_estimate - offset);
                 }
-                offset += step;
+                let next = offset + step;
+                if next <= offset {
+                    // f32 saturation: adding `step` no longer changes `offset`.
+                    break;
+                }
+                offset = next;
             }
         }
     }
@@ -1505,5 +1541,25 @@ mod tests {
         assert!(apparent[2].abs() < 1e-7, "Z not zero: {}", apparent[2]);
         // X should still be ~1.0 (normalized)
         assert!((apparent[0] - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_build_fov_sweep_terminates_on_extreme_max_error() {
+        // Regression: with `offset += step` stalling below f32 precision, an
+        // infinite/huge max_error used to loop (and push) forever. Values at
+        // or beyond π are meaningless, so the sweep must clamp and terminate.
+        let fov = 10.0_f32.to_radians();
+        for max_error in [f32::INFINITY, f32::MAX, 1e30] {
+            let values = build_fov_sweep(fov, Some(max_error), 0.003, 1.2);
+            assert!(!values.is_empty());
+            assert!(
+                values.len() < 100_000,
+                "sweep exploded to {} values for max_error {max_error}",
+                values.len()
+            );
+        }
+        // NaN and negative skip the sweep entirely, leaving just the estimate.
+        assert_eq!(build_fov_sweep(fov, Some(f32::NAN), 0.003, 1.2).len(), 1);
+        assert_eq!(build_fov_sweep(fov, Some(-1.0), 0.003, 1.2).len(), 1);
     }
 }

--- a/src/starcatalog.rs
+++ b/src/starcatalog.rs
@@ -32,16 +32,32 @@ pub struct StarCatalog {
     star_indices: Vec<u32>,
 }
 
+/// Largest `nside` accepted by [`StarCatalog::new`] (and enforced by
+/// [`StarCatalog::validate`]). The index allocates `12 * nside²` cells, so an
+/// unbounded value is a memory-exhaustion vector (`nside = 10_000` ≈ 29 GB of
+/// bin headers) and overflows the `u32` cell arithmetic near `nside ≈ 19_000`.
+/// 1024 (12.6M cells) is far beyond any practical star-density need — the
+/// default is 16.
+pub const MAX_NSIDE: u32 = 1024;
+
 impl StarCatalog {
     /// Build a catalog and spatial index from owned stars.
     ///
-    /// `nside` controls resolution and must be greater than zero.
-    /// The number of sky cells is `12 * nside^2`.
+    /// `nside` controls resolution. The number of sky cells is `12 * nside^2`.
+    ///
+    /// # Panics
+    ///
+    /// Panics unless `1 <= nside <= MAX_NSIDE`. Config-driven callers
+    /// ([`crate::GenerateDatabaseConfig`]) reject out-of-range values with an
+    /// error before reaching this constructor.
     pub fn new(nside: u32, stars: Vec<Star>) -> Self {
-        assert!(nside > 0, "nside must be > 0");
+        assert!(
+            nside > 0 && nside <= MAX_NSIDE,
+            "nside must be in [1, {MAX_NSIDE}], got {nside}"
+        );
         let n_lat = 3 * nside;
         let n_lon = 4 * nside;
-        let n_cells = (n_lat * n_lon) as usize;
+        let n_cells = (n_lat as usize) * (n_lon as usize);
 
         let mut bins: Vec<Vec<u32>> = vec![Vec::new(); n_cells];
         for (star_idx, star) in stars.iter().enumerate() {
@@ -85,6 +101,62 @@ impl StarCatalog {
     /// Return all catalog stars as an immutable slice.
     pub fn stars(&self) -> &[Star] {
         &self.stars
+    }
+
+    /// Check the spatial-index invariants that [`Self::new`] establishes by
+    /// construction but that serde deserialization can bypass (the fields are
+    /// private, yet `#[derive(Deserialize)]` writes them directly).
+    ///
+    /// Every cone query indexes `cell_offsets`, `star_indices`, and `stars`
+    /// with values derived from these fields, so a catalog decoded from a
+    /// corrupt or tampered file must pass this check before use — otherwise
+    /// the first query panics out-of-bounds. Called by
+    /// [`crate::SolverDatabase::load_from_file`].
+    pub fn validate(&self) -> crate::Result<()> {
+        use crate::Error::InvalidInput;
+        if self.nside == 0 || self.nside > MAX_NSIDE {
+            return Err(InvalidInput(format!(
+                "StarCatalog: nside must be in [1, {MAX_NSIDE}], got {}",
+                self.nside
+            )));
+        }
+        if self.n_lat != 3 * self.nside || self.n_lon != 4 * self.nside {
+            return Err(InvalidInput(format!(
+                "StarCatalog: n_lat/n_lon ({}/{}) inconsistent with nside {}",
+                self.n_lat, self.n_lon, self.nside
+            )));
+        }
+        let n_cells = (self.n_lat as usize) * (self.n_lon as usize);
+        if self.cell_offsets.len() != n_cells + 1 {
+            return Err(InvalidInput(format!(
+                "StarCatalog: cell_offsets has {} entries, expected {} (12*nside²+1)",
+                self.cell_offsets.len(),
+                n_cells + 1
+            )));
+        }
+        if self.cell_offsets[0] != 0
+            || self.cell_offsets.windows(2).any(|w| w[0] > w[1])
+            || self.cell_offsets[n_cells] as usize != self.star_indices.len()
+        {
+            return Err(InvalidInput(
+                "StarCatalog: cell_offsets must rise monotonically from 0 to star_indices.len()"
+                    .into(),
+            ));
+        }
+        let n_stars = self.stars.len();
+        if self.star_indices.len() != n_stars {
+            return Err(InvalidInput(format!(
+                "StarCatalog: star_indices has {} entries for {} stars",
+                self.star_indices.len(),
+                n_stars
+            )));
+        }
+        if self.star_indices.iter().any(|&i| i as usize >= n_stars) {
+            return Err(InvalidInput(
+                "StarCatalog: star_indices contains an index past the star table".into(),
+            ));
+        }
+        Ok(())
     }
 
     /// Query stars within an angular radius of a pointing direction.
@@ -352,6 +424,85 @@ mod tests {
         let mut hit_ids: Vec<i64> = hits.iter().map(|s| s.id).collect();
         hit_ids.sort_unstable();
         assert_eq!(hit_ids, expected);
+    }
+
+    /// Field-for-field mirror of `StarCatalog`'s postcard wire layout, used to
+    /// craft catalogs that violate the private-field invariants — exactly what
+    /// a corrupt or tampered database file can produce through serde.
+    #[derive(serde::Serialize)]
+    struct RawCatalog {
+        nside: u32,
+        n_lat: u32,
+        n_lon: u32,
+        stars: Vec<Star>,
+        cell_offsets: Vec<u32>,
+        star_indices: Vec<u32>,
+    }
+
+    #[test]
+    fn validate_accepts_constructed_and_rejects_tampered() {
+        let stars = vec![Star {
+            id: 1,
+            ra_rad: 0.5,
+            dec_rad: 0.2,
+            mag: 3.0,
+        }];
+        let catalog = StarCatalog::new(2, stars.clone());
+        assert!(catalog.validate().is_ok());
+
+        // Round-trip through postcard stays valid.
+        let bytes = postcard::to_allocvec(&catalog).unwrap();
+        let decoded: StarCatalog = postcard::from_bytes(&bytes).unwrap();
+        assert!(decoded.validate().is_ok());
+
+        let decode = |raw: &RawCatalog| -> StarCatalog {
+            postcard::from_bytes(&postcard::to_allocvec(raw).unwrap()).unwrap()
+        };
+
+        // Each of these decodes cleanly but would panic (OOB index or u32
+        // underflow) inside the first cone query without validate().
+        let n_cells = 6 * 8; // nside 2
+        let cases = [
+            RawCatalog {
+                nside: 0, // n_lat-1 underflow in z_to_lat_bin
+                n_lat: 0,
+                n_lon: 0,
+                stars: stars.clone(),
+                cell_offsets: vec![0],
+                star_indices: vec![0],
+            },
+            RawCatalog {
+                nside: 2,
+                n_lat: 6,
+                n_lon: 8,
+                stars: stars.clone(),
+                cell_offsets: vec![0; 3], // too short for 48 cells
+                star_indices: vec![0],
+            },
+            RawCatalog {
+                nside: 2,
+                n_lat: 6,
+                n_lon: 8,
+                stars: stars.clone(),
+                cell_offsets: vec![7; n_cells + 1], // offsets past star_indices
+                star_indices: vec![0],
+            },
+            RawCatalog {
+                nside: 2,
+                n_lat: 6,
+                n_lon: 8,
+                stars: stars.clone(),
+                cell_offsets: {
+                    let mut o = vec![0; n_cells + 1];
+                    o[n_cells] = 1;
+                    o
+                },
+                star_indices: vec![99], // index past the 1-star table
+            },
+        ];
+        for (i, raw) in cases.iter().enumerate() {
+            assert!(decode(raw).validate().is_err(), "case {i} passed validate");
+        }
     }
 
     #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -846,6 +846,58 @@ fn test_save_and_load_database() {
 
     // Clean up temporary file
     std::fs::remove_file(tmp_path).expect("Failed to delete temporary file");
+
+    // ── Corruption is rejected at load, not deferred to a mid-solve panic ──
+    // Each tampered database decodes cleanly through postcard; without
+    // validate() the inconsistency only surfaces as an out-of-bounds index
+    // (or unbounded key enumeration) during solve_from_centroids.
+    let n_stars = db.star_catalog.len() as u32;
+
+    let mut tampered = db.clone();
+    tampered.star_vectors.truncate(db.star_vectors.len() / 2);
+    assert!(
+        tampered.validate().is_err(),
+        "truncated star_vectors must fail validation"
+    );
+
+    let mut tampered = db.clone();
+    tampered.star_catalog_ids.push(0);
+    assert!(
+        tampered.validate().is_err(),
+        "over-long star_catalog_ids must fail validation"
+    );
+
+    let mut tampered = db.clone();
+    let slot = tampered
+        .pattern_catalog
+        .entries
+        .iter()
+        .position(|e| !e.is_empty())
+        .expect("generated database has at least one pattern");
+    tampered.pattern_catalog.entries[slot].star_indices = [n_stars, 0, 0, 0];
+    assert!(
+        tampered.validate().is_err(),
+        "pattern entry indexing past the star table must fail validation"
+    );
+
+    let mut tampered = db.clone();
+    tampered.props.pattern_bins = u32::MAX; // would explode key enumeration
+    assert!(
+        tampered.validate().is_err(),
+        "pattern_bins inconsistent with pattern_max_error must fail validation"
+    );
+
+    // And end-to-end: a bit-flipped file either fails to decode (postcard) or
+    // fails validation — it must never load successfully with corrupt indices.
+    let bad_path = "temp_db_corrupt.bin";
+    tampered.star_vectors.truncate(3);
+    let bytes = tampered.to_bytes().expect("serialize tampered db");
+    std::fs::write(bad_path, &bytes).expect("write corrupt db");
+    assert!(
+        SolverDatabase::load_from_file(bad_path).is_err(),
+        "corrupt database file must be rejected at load"
+    );
+    std::fs::remove_file(bad_path).ok();
 }
 
 /// Solve 1000 random orientations with a 10° FOV camera and 4"/axis centroid noise.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -682,6 +682,9 @@ fn test_statistical_1000_random_orientations() {
                     all_solve_times_ms.push(fail.solve_time_ms);
                 }
                 SolveStatus::TooFew => n_too_few += 1,
+                SolveStatus::InvalidConfig => {
+                    panic!("statistical trials use a valid config; got InvalidConfig")
+                }
             },
         }
 
@@ -887,6 +890,27 @@ fn test_save_and_load_database() {
         "pattern_bins inconsistent with pattern_max_error must fail validation"
     );
 
+    // An invalid solve config fails fast with InvalidConfig instead of
+    // burning the search to a guaranteed NoMatch (or warn-and-proceed).
+    let dummy_centroids: Vec<Centroid> = (0..6)
+        .map(|i| Centroid {
+            x: 40.0 * i as f32 - 100.0,
+            y: 25.0 * i as f32 - 60.0,
+            mass: Some(100.0),
+            cov: None,
+        })
+        .collect();
+    let fail = db
+        .solve_from_centroids(&dummy_centroids, &SolveConfig::default())
+        .expect_err("placeholder camera model must not solve");
+    assert_eq!(fail.status, SolveStatus::InvalidConfig);
+    let mut bad_cfg = SolveConfig::new(20.0_f32.to_radians(), 1024, 768);
+    bad_cfg.match_radius = f32::NAN;
+    let fail = db
+        .solve_from_centroids(&dummy_centroids, &bad_cfg)
+        .expect_err("NaN match_radius must not solve");
+    assert_eq!(fail.status, SolveStatus::InvalidConfig);
+
     // And end-to-end: a bit-flipped file either fails to decode (postcard) or
     // fails validation — it must never load successfully with corrupt indices.
     let bad_path = "temp_db_corrupt.bin";
@@ -1062,6 +1086,9 @@ fn test_statistical_1000_noisy_centroids() {
                     all_solve_times_ms.push(fail.solve_time_ms);
                 }
                 SolveStatus::TooFew => n_too_few += 1,
+                SolveStatus::InvalidConfig => {
+                    panic!("statistical trials use a valid config; got InvalidConfig")
+                }
             },
         }
 


### PR DESCRIPTION
## Summary

Full-crate audit for reachable panics, memory issues, and improper argument handling, motivated by treating tetra3 as a library component inside an accredited system (ASD STIG invalid-input handling). Everything is fixed by one principle: **validate at trust boundaries** — file load, pickle bytes, and public constructors — so corrupt data and degenerate arguments fail with a descriptive error instead of a deferred panic, hang, or silently-wrong result. No solver-algorithm changes; outputs on valid inputs are unchanged (skyview/TESS metrics identical).

## Fixed

- **Corrupt/tampered databases and pickles rejected at load**: new `validate()` on `SolverDatabase`, `StarCatalog`, `CameraModel`, and the distortion types, called from `load_from_file` and every Python `_from_pickle_bytes`. Previously a file that decoded cleanly via postcard could panic out-of-bounds mid-solve (pattern entries past the star table, inconsistent spatial index, mismatched vector lengths) or inflate the key enumeration without bound (`pattern_bins` inconsistent with `pattern_max_error`).
- **Infinite loop / unbounded memory in the FOV sweep** with `fov_max_error_rad: Some(f32::INFINITY)` (f32 step saturation, ran before any timeout check); candidates implying a FOV outside `(0, π)` are also skipped.
- **Hipparcos parser panicked on multi-byte UTF-8** straddling a fixed-width column boundary.
- **`PolynomialDistortion` order/coefficient mismatches panicked OOB** — `num_coeffs` u32 wrap closed (incl. the Python `order=2**32-1` hole), `MAX_POLY_ORDER` bound, NaN-triggerable `debug_assert` in `undistort` removed.
- **Single-image `calibrate_camera` returned a fabricated perfect calibration** (identity distortion, RMSE 0) on a no-fit — now errors per its documented contract; argument asserts became `InvalidInput`.
- **Gaia loader**: 32-bit star-count truncation, non-finite records skipped with a warning; 32-bit `width*height` wrap in extraction closed; `matched_filter_sigma` capped (kernel allocation scales with σ); generation errors instead of OOM on tiny `min_fov_deg` / huge `catalog_nside`.

## Changed (breaking → 0.10.0)

- `SolverDatabase::to_bytes` returns `crate::Result<Vec<u8>>`.
- New `SolveStatus::InvalidConfig` + public `SolveConfig::validate()`: degenerate configs (placeholder camera model, NaN match params) fail fast instead of warn-and-burn-the-search-to-NoMatch. Variant appended last so serialized statuses keep their wire values.
- `CameraModel::from_fov` / `StarCatalog::new` validate in release builds (documented panics); Python raises `ValueError` for these and all degenerate constructor args.
- Python releases the GIL during solve / generate / calibrate / load / extraction.

Also fixes stale CLAUDE.md claims (rkyv → postcard; no in-tree CSV parser) and adds an upgrade guide to the CHANGELOG. Version bumped in all three files per the release checklist (Cargo.toml, root pyproject.toml, python/Cargo.toml).

## Testing

- Rust: 90 lib tests (incl. new regression tests: tampered-catalog/database rejection via serde mirror structs, sweep termination, char-boundary parsing, config validation), full `--features image` release integration incl. 10-image TESS calibration — all green.
- Python: 92 tests incl. new `ValueError`/`invalid_config`/corrupt-pickle cases.
- `cargo fmt --check` + `clippy --all-targets --all-features -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Dependencies / CI (added after initial review body)

- `numeris` 0.5.14 → 0.5.17; Python bindings upgraded to pyo3 0.29.2 / numpy 0.29.0.
- CI: fixed a new clippy lint and the RUSTSEC-2026-0204 advisory.



---

## Changelog detail (moved from CHANGELOG.md on 2026-08-29)

The release-notes text for 0.10.0 that shipped in `CHANGELOG.md` before it was condensed to one-liners. Preserved here verbatim so the PR is the record of detail.


Robustness sweep: validate at every trust boundary (file load, pickle,
public constructors) so corrupt data and degenerate arguments fail with a
descriptive error instead of a deferred panic, hang, or silently-wrong
result. No solver-algorithm changes; all outputs on valid inputs are
unchanged.

### Upgrading from 0.9

- `SolverDatabase::to_bytes` returns `crate::Result<Vec<u8>>` — add `?`.
- Exhaustive matches on `SolveStatus` need a new `InvalidConfig` arm, and
  solves with a degenerate config (e.g. the `Default::default()`
  placeholder camera model) now return it instead of `NoMatch`.
- `CameraModel::from_fov` panics on FOV outside `(0, π)` in release builds
  too (previously debug-only); Python raises `ValueError`.
- Corrupt database/camera files and pickles now fail at load
  (`InvalidInput` / Python `ValueError`) instead of panicking on first use.

### Fixed

- **Corrupt/tampered database files and pickles are rejected at load.**
  `SolverDatabase::load_from_file` (and the Python pickle path) now run a
  full invariant check — `StarCatalog` spatial-index consistency, pattern
  entries within the star table, `star_vectors`/`star_catalog_ids` length
  agreement, and sane `DatabaseProperties` (including
  `pattern_bins`-vs-`pattern_max_error` consistency, which previously let a
  crafted file inflate the key enumeration without bound). Previously a file
  that decoded cleanly could panic out-of-bounds mid-solve. New public
  `SolverDatabase::validate` / `StarCatalog::validate`.
  `CameraModel::load_from_file` and the pickle paths for `CameraModel`,
  `RadialDistortion`, `PolynomialDistortion`, `SolveResult`, and
  `CalibrateResult` validate the same way (Python: `ValueError`).
- **Infinite loop / unbounded memory in the FOV sweep** with
  `fov_max_error_rad: Some(f32::INFINITY)` (or any value large enough to
  stall the f32 step accumulation). The sweep now clamps to π and detects
  step saturation. Candidate matches implying a FOV outside `(0, π)` are
  also skipped (previously they degenerated the verification statistics).
- **Hipparcos parser panicked on multi-byte UTF-8** straddling a fixed-width
  column boundary; such lines are now skipped like any other malformed
  record.
- **`PolynomialDistortion` order/coefficient mismatches panicked
  out-of-bounds** on first use. `num_coeffs` no longer wraps for absurd
  orders (this also closes the Python hole where
  `PolynomialDistortion(order=2**32-1, a_coeffs=[], b_coeffs=[])`
  constructed and panicked on `.distort()`); constructors bound `order` by
  the new `MAX_POLY_ORDER` (12); `validate()` checks the invariants at
  deserialization boundaries. The debug-only assert on the Newton Jacobian
  in `undistort` (which fired on NaN input) is removed — the existing
  release-path bailout handles it.
- **Single-image `calibrate_camera` returned a fabricated perfect result**
  (identity distortion, RMSE 0, 0 inliers) when the fit had too few matched
  points, contradicting its documented error contract. It now returns
  `InvalidInput` like the multi-image path.
- **Gaia binary loader**: the star count no longer silently truncates on
  32-bit targets, and records with non-finite ra/dec/mag/pm are skipped
  with a warning instead of silently poisoning the spatial index.
  32-bit `width*height` overflow in the extraction buffer check is also
  closed.

### Changed

- **New `SolveStatus::InvalidConfig` variant** (breaking for exhaustive
  matches): `solve_from_centroids` now runs the new public
  `SolveConfig::validate()` first and fails fast with `InvalidConfig`
  instead of warn-and-proceed to a guaranteed `NoMatch` — for the
  `Default::default()` placeholder camera model, non-finite
  `match_radius`/`match_threshold`, non-finite `fov_max_error_rad` /
  `match_max_error` / `observer_velocity_km_s`, and (when a hint is set) a
  degenerate `hint_uncertainty_rad`. Python: `SolveFailure.status` gains
  `'invalid_config'`. The variant is appended after the 0.9 ones, so
  previously serialized statuses keep their wire values.
- **`CameraModel::from_fov` and `StarCatalog::new` validate in release
  builds** (documented panics). Previously `from_fov` checked only in debug,
  so release builds accepted `fov=0`/`≥180°`/NaN and silently produced
  infinite/negative/NaN focal lengths. From Python these are `ValueError`s
  (as are zero image dimensions, degenerate `CameraModel` constructor args,
  and non-finite distortion coefficients).
- **`SolverDatabase::to_bytes` returns `crate::Result<Vec<u8>>`** (breaking)
  instead of panicking on serialization failure.
- **`calibrate_camera` argument errors are `Err(InvalidInput)`** instead of
  panics (mismatched slice lengths, polynomial order outside `[2, 6]`). The
  lower-level `fit_*_distortion` functions keep their asserts, now
  documented.
- **Generation limits**: `GenerateDatabaseConfig::validate` bounds
  `catalog_nside` by `MAX_NSIDE` (1024) and requires a plausible
  `epoch_proper_motion_year`; generation errors (instead of OOM) when the
  lattice would exceed 10⁸ points (tiny `min_fov_deg` × high oversampling).
  `matched_filter_sigma` above 64 px is rejected (the kernel allocation
  scales with σ).
- **Python: the GIL is released during long native calls** —
  `solve_from_centroids`, `generate_from_gaia`, `calibrate_camera`,
  `load_from_file`, and both extraction functions — so other Python threads
  keep running.

### Dependencies

- Bumped `numeris` 0.5.14 → 0.5.17.
- Python bindings: upgraded `pyo3` to 0.29.2 and `numpy` to 0.29.0.

