### PR TITLE
perf(python): contiguous-slice fast path for image conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Only recent releases are listed. Older entries are in this file's git history (`
 
 ## Unreleased
 
+### Changed
+
+- Python: `extract_centroids` / `extract_centroids_fast` convert C-contiguous numpy images straight from the flat slice (memcpy for f32), saving ~2.4 ms per 2048² frame; non-contiguous views keep the strided path, output unchanged ([#52](https://github.com/ssmichael1/tetra3rs/pull/52))
+
 ## 0.11.0 - 2026-08-30
 
 ### Added

--- a/python/src/extraction.rs
+++ b/python/src/extraction.rs
@@ -34,6 +34,39 @@ impl From<CentroidExtractionResult> for ExtractionData {
     }
 }
 
+/// A numpy element type accepted as an image pixel.
+trait Pixel: numpy::Element + Copy {
+    fn to_f32(self) -> f32;
+
+    /// Convert a contiguous run of pixels. Default is the element-wise cast;
+    /// `f32` overrides it with a plain memcpy.
+    fn slice_to_f32(s: &[Self]) -> Vec<f32> {
+        s.iter().map(|&v| v.to_f32()).collect()
+    }
+}
+
+macro_rules! impl_pixel_as_f32 {
+    ($($t:ty),*) => {$(
+        impl Pixel for $t {
+            #[inline]
+            fn to_f32(self) -> f32 {
+                self as f32
+            }
+        }
+    )*};
+}
+impl_pixel_as_f32!(f64, u8, u16, i16);
+
+impl Pixel for f32 {
+    #[inline]
+    fn to_f32(self) -> f32 {
+        self
+    }
+    fn slice_to_f32(s: &[f32]) -> Vec<f32> {
+        s.to_vec()
+    }
+}
+
 /// Convert a 2D numpy array of any supported dtype to Vec<f32>.
 ///
 /// Supported dtypes: float64, float32, uint8, uint16, int16. Non-native byte
@@ -70,23 +103,29 @@ fn image_to_f32(image: &Bound<'_, pyo3::PyAny>) -> PyResult<(Vec<f32>, u32, u32)
     let itemsize: usize = dtype.getattr("itemsize")?.extract()?;
 
     /// Extract one supported dtype and convert element-wise to f32.
-    fn arr_to_f32<T: numpy::Element + Copy>(
-        image: &Bound<'_, pyo3::PyAny>,
-        to_f32: impl Fn(T) -> f32,
-    ) -> PyResult<(Vec<f32>, u32, u32)> {
+    ///
+    /// A C-contiguous array converts straight from its flat slice (~5x cheaper
+    /// than ndarray's generic strided iterator on a 2048² frame); any other
+    /// layout (Fortran order, negative/step strides) takes the strided path.
+    /// Both produce identical values.
+    fn arr_to_f32<T: Pixel>(image: &Bound<'_, pyo3::PyAny>) -> PyResult<(Vec<f32>, u32, u32)> {
         let arr: PyReadonlyArray2<T> = image.extract()?;
         let a = arr.as_array();
         let h = a.shape()[0] as u32;
         let w = a.shape()[1] as u32;
-        Ok((a.iter().map(|&v| to_f32(v)).collect(), w, h))
+        let pixels = match a.as_slice() {
+            Some(s) => T::slice_to_f32(s),
+            None => a.iter().map(|&v| v.to_f32()).collect(),
+        };
+        Ok((pixels, w, h))
     }
 
     match (kind.as_str(), itemsize) {
-        ("f", 8) => arr_to_f32::<f64>(image, |v| v as f32),
-        ("f", 4) => arr_to_f32::<f32>(image, |v| v),
-        ("u", 1) => arr_to_f32::<u8>(image, |v| v as f32),
-        ("u", 2) => arr_to_f32::<u16>(image, |v| v as f32),
-        ("i", 2) => arr_to_f32::<i16>(image, |v| v as f32),
+        ("f", 8) => arr_to_f32::<f64>(image),
+        ("f", 4) => arr_to_f32::<f32>(image),
+        ("u", 1) => arr_to_f32::<u8>(image),
+        ("u", 2) => arr_to_f32::<u16>(image),
+        ("i", 2) => arr_to_f32::<i16>(image),
         _ => {
             let dtype_str: String = dtype.str()?.extract()?;
             Err(pyo3::exceptions::PyTypeError::new_err(format!(

--- a/python/tests/test_basic.py
+++ b/python/tests/test_basic.py
@@ -474,6 +474,48 @@ class TestExtractCentroids:
         # Same values in → same centroid position out.
         assert abs(r_native.centroids[0].x - r_big.centroids[0].x) < 1e-4
 
+    @pytest.mark.parametrize(
+        "extract",
+        [tetra3rs.extract_centroids, tetra3rs.extract_centroids_fast],
+        ids=["ccl", "fast"],
+    )
+    def test_layout_and_dtype_give_identical_centroids(self, extract):
+        """C-contiguous input takes a slice fast path; strided views and
+        other dtypes must produce bit-identical centroids."""
+        h, w = 256, 320
+        rng = np.random.default_rng(7)
+        image = rng.normal(500, 8, (h, w))
+        yy, xx = np.mgrid[0:h, 0:w]
+        for cy, cx in [(40, 60), (120, 200), (200, 90), (180, 280)]:
+            image += 20000 * np.exp(
+                -((yy - cy) ** 2 + (xx - cx) ** 2) / (2 * 1.8**2)
+            )
+        u16 = np.ascontiguousarray(np.clip(image, 0, 65535).astype(np.uint16))
+        assert u16.flags.c_contiguous
+
+        def key(img):
+            r = extract(img, sigma_threshold=5.0, max_centroids=20)
+            assert len(r.centroids) >= 3
+            return [(c.x, c.y, c.brightness) for c in r.centroids]
+
+        ref = key(u16)
+        # Same pixels, non-contiguous layouts (strided fallback path).
+        fortran = np.asfortranarray(u16)
+        assert not fortran.flags.c_contiguous
+        assert key(fortran) == ref
+        padded = np.zeros((h, w + 8), dtype=np.uint16)
+        padded[:, 4 : 4 + w] = u16
+        window = padded[:, 4 : 4 + w]  # row stride != w: not contiguous
+        assert not window.flags.c_contiguous
+        assert key(window) == ref
+        # Same pixels, other dtypes (each exactly representable in f32).
+        for dtype in (np.int16, np.float32, np.float64):
+            assert key(u16.astype(dtype)) == ref, dtype
+        # A step-sliced view vs. its contiguous copy.
+        view = u16[::2, ::2]
+        assert not view.flags.c_contiguous
+        assert key(view) == key(np.ascontiguousarray(view))
+
     def test_fast_result_pickle_and_drop_in(self):
         """Fast path returns a pickleable ExtractionResult with usable centroids."""
         h, w = 64, 64


### PR DESCRIPTION
## Cause

Profiling `tetra3rs.extract_centroids_fast` on a 2048² frame showed a ~2.4 ms fixed cost over the Rust core, the same for every dtype (u16 / i16 / f32 / f64). `image_to_f32` in `python/src/extraction.rs` converted every numpy image through ndarray's generic strided `ArrayView2::iter().map().collect()`, which cannot vectorise. A micro-benchmark of the conversion alone showed a contiguous-slice path is ~5× cheaper (u16 1.23 → 0.25 ms, f32 1.36 → 0.31 ms via `to_vec`, f64 1.39 → 0.55 ms). With the core about to get several times faster, this boundary copy would have become larger than the extraction itself.

## Change

`arr_to_f32` now tries `as_slice()` (C-contiguous / standard layout) first and converts from the flat slice — a plain `to_vec()` memcpy for f32, an element-wise `as f32` cast for u8/u16/i16/f64 — via a small private `Pixel` trait. Any non-contiguous input (Fortran order, negative / step strides, padded windows) falls back to the existing strided iterator. The values produced are identical on both paths. This covers both `extract_centroids` and `extract_centroids_fast` (the only image entry points; nothing else in `python/src/` converts a 2D image).

Zero-copy for a native contiguous f32 array was considered and skipped: it would require holding the numpy read borrow across `py.detach()`, which is a soundness hazard (another Python thread could mutate the buffer while the GIL is released) for a ~0.3 ms gain.

No changes under `src/` (Rust core).

## Timings

`timeit`, best of 20, 2048×2048 synthetic star field, Apple Silicon, Python 3.14, numpy 2.5. Baseline measured on the same build tree with the change stashed.

| `extract_centroids_fast` input | before | after |
|---|---|---|
| u16 C-contiguous | 9.99 ms | 7.56 ms |
| i16 C-contiguous | 9.99 ms | 7.53 ms |
| f32 C-contiguous | 9.84 ms | 7.69 ms |
| f64 C-contiguous | 10.02 ms | 8.00 ms |
| u16 Fortran order (strided fallback) | 13.41 ms | 13.19 ms |
| u16 `[:, ::-1]` view (strided fallback) | 13.11 ms | 13.09 ms |

`extract_centroids` (CCL path) on u16 C-contiguous: 20.2 → 18.5 ms (best of 5).

Contiguous input saves ~2.3–2.4 ms per call — the whole boundary overhead — and the strided fallback is unchanged.

## Tests

- New `TestExtractCentroids::test_layout_and_dtype_give_identical_centroids`, parametrised over `extract_centroids` and `extract_centroids_fast`: the same pixels as C-contiguous u16 (fast path), Fortran-order and padded-window views (strided fallback), and as i16 / f32 / f64, must yield identical `(x, y, brightness)` centroid lists; a `[::2, ::2]` step-sliced view must match its contiguous copy.
- Full Python suite: 98 passed. `cargo fmt --check` and `cargo clippy --all-targets -D warnings` clean on the `python/` crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q27Wdq3SRmb8w612idHkRw
