### PR TITLE
perf: bit-mask run sweep for fast centroider (6x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Only recent releases are listed. Older entries are in this file's git history (`
 
 ## Unreleased
 
+### Changed
+
+- `extract_centroids_fast` thresholds each row into a packed bit mask (per-column background plan precomputed once, `p > thr[c]` vectorized) and reads runs off the bits with `trailing_zeros`/`trailing_ones` instead of calling a per-pixel closure: ~6× faster on tracker-like frames (2048²: 7.3 → 1.2 ms), ~2.6× on dense survey frames; with `parallel` the mask is built row-parallel (2048²: 0.53 ms, ~13×). Output is bit-identical. ([#53](https://github.com/ssmichael1/tetra3rs/pull/53))
+- `BackgroundGrid::build` streams each block row across its blocks (one task per block row under `parallel`) instead of a strided gather per block, and the brightness sort orders `(mass, index)` keys with an unstable sort; both bit-identical. ([#53](https://github.com/ssmichael1/tetra3rs/pull/53))
+
 ## 0.11.0 - 2026-08-30
 
 ### Added

--- a/src/centroid_extraction/fast.rs
+++ b/src/centroid_extraction/fast.rs
@@ -1,10 +1,10 @@
 //! Fast single-pass star-tracker extraction path: coarse subsampled
-//! background grid + one raster sweep with run-length connected regions and
-//! inline moment accumulation. Split out of the crate-facing module; entry via
-//! [`extract_centroids_fast`].
+//! background grid + one thresholding pass into a packed bit mask + a
+//! run-length sweep over the mask, with moments computed from the run lists.
+//! Split out of the crate-facing module; entry via [`extract_centroids_fast`].
 
 use super::{
-    check_pixel_len, elongation_from_cov, finish_region, runs, sort_and_truncate_by_mass,
+    check_pixel_len, elongation_from_cov, finish_region, par, runs, sort_and_truncate_by_mass,
     BackgroundGrid, CentroidExtractionResult,
 };
 use crate::centroid::Centroid;
@@ -100,13 +100,16 @@ impl Default for FastCentroidConfig {
 ///
 /// An alternative to [`extract_centroids_from_raw`](super::extract_centroids_from_raw) that reads each pixel
 /// **once**: a cheap subsampled pre-pass builds a coarse background grid, then
-/// a single raster sweep thresholds against the bilinearly-interpolated
-/// background, groups lit pixels into connected regions via run-length +
-/// union-find (accumulating intensity-weighted moments inline), and emits a
-/// center-of-mass per region. No convolution, no full-image background buffer,
-/// no second pass — so it is memory-bandwidth-bound rather than compute-bound,
-/// and markedly faster than the connected-component path (which stays the
-/// default and the right choice for calibration / faint-star work).
+/// a single pass thresholds every row against the bilinearly-interpolated
+/// background into a packed bit mask (1 bit per pixel), a run-length +
+/// union-find sweep over the mask groups lit pixels into connected regions
+/// (work proportional to runs, not pixels), and intensity-weighted moments
+/// over the run lists give a center-of-mass per region. No convolution, no
+/// full-image background buffer, no second pass over the image — so it runs
+/// close to memory bandwidth and markedly faster than the connected-component
+/// path (which stays the default and the right choice for calibration /
+/// faint-star work). With the `parallel` feature the background grid and the
+/// bit mask are built multi-threaded; results are bit-identical either way.
 ///
 /// # Trade-offs
 ///
@@ -152,23 +155,34 @@ pub fn extract_centroids_fast(
     let (bg, sigma) = BackgroundGrid::build(pixels, w, h, block, (block / 8).max(1));
     let nx = w.div_ceil(block);
     let k = config.sigma_threshold;
+    let k_sigma = k * sigma;
 
-    // ── Single raster sweep via the shared run-length core ──
-    // The `lit` closure hoists the row-constant half of the background
-    // interpolation itself (rebuilt when the row changes); moments are
-    // computed afterwards from the run lists — lit pixels are ≪1% of the
-    // image, so the second touch of them is nearly free and keeps the sweep
-    // core shared with the quality path.
-    let mut grid_row = vec![0.0_f32; nx];
-    let mut grid_row_y = usize::MAX;
-    let regions = runs::sweep_runs(w, h, |r, c| {
-        if r != grid_row_y {
+    // ── Threshold pass: packed detection bit mask ──
+    // Per row: blend the two bracketing grid rows (row-constant half of the
+    // interpolation), expand to a per-column threshold through the grid's
+    // precomputed column plan, and compare the pixels into one bit each.
+    // The whole-image mask (h × ⌈w/64⌉ words; 512 KB at 2048²) is filled in
+    // independent 16-row chunks — multi-threaded under `parallel` — and
+    // then consumed by one sequential run sweep, so region ids are
+    // identical to a pixel-by-pixel raster sweep. Moments are computed
+    // afterwards from the run lists: lit pixels are ≪1% of the image, so
+    // the second touch of them is nearly free.
+    const ROWS_PER_CHUNK: usize = 16;
+    let words_per_row = w.div_ceil(64);
+    let mut mask = vec![0u64; words_per_row * h];
+    par::for_each_chunk_mut(&mut mask, words_per_row * ROWS_PER_CHUNK, |ci, chunk| {
+        let mut grid_row = vec![0.0_f32; nx];
+        let mut thr = vec![0.0_f32; w];
+        for (i, words) in chunk.chunks_exact_mut(words_per_row).enumerate() {
+            let r = ci * ROWS_PER_CHUNK + i;
             bg.blend_row(bg.row_params(r), &mut grid_row);
-            grid_row_y = r;
+            bg.threshold_row(&grid_row, k_sigma, &mut thr);
+            pack_lit_row(&pixels[r * w..(r + 1) * w], &thr, words);
         }
-        let p = pixels[r * w + c];
-        p.is_finite() && p > bg.lerp_in_row(&grid_row, c) + k * sigma
     });
+
+    // ── Run-length sweep over the mask via the shared core ──
+    let regions = runs::sweep_runs_mask(w, h, words_per_row, &mask);
     let (offsets, order) = regions.group_by_region();
 
     // ── Emit one centroid per region ──
@@ -279,4 +293,67 @@ pub fn extract_centroids_fast(
         threshold: bg_mean + k * sigma,
         num_blobs_raw,
     })
+}
+
+/// Pack one image row's detection mask: bit `c % 64` of `words[c / 64]` is
+/// set when `row[c]` is finite and exceeds `thr[c]`. `(p > t) & (p < +∞)` is
+/// exactly `p.is_finite() && p > t` (NaN fails both compares, −∞ fails the
+/// first, +∞ the second) but branch-free: the compares fill a 64-byte
+/// scratch (a vectorizable loop), then each 8 bytes fold to 8 bits with the
+/// multiply-shift trick. Padding bits at or beyond `row.len()` are zero.
+#[inline]
+fn pack_lit_row(row: &[f32], thr: &[f32], words: &mut [u64]) {
+    debug_assert_eq!(row.len(), thr.len());
+    debug_assert_eq!(words.len(), row.len().div_ceil(64));
+    for (wi, word) in words.iter_mut().enumerate() {
+        let c0 = wi * 64;
+        let c1 = (c0 + 64).min(row.len());
+        let mut bytes = [0u8; 64];
+        for ((m, &p), &t) in bytes.iter_mut().zip(&row[c0..c1]).zip(&thr[c0..c1]) {
+            *m = ((p > t) & (p < f32::INFINITY)) as u8;
+        }
+        let mut acc = 0u64;
+        for (k, chunk) in bytes.as_chunks::<8>().0.iter().enumerate() {
+            let x = u64::from_le_bytes(*chunk);
+            // Each byte is 0 or 1; the multiply gathers the low bit of each
+            // byte into the top byte, lowest byte → lowest bit.
+            acc |= (x.wrapping_mul(0x0102_0408_1020_4080) >> 56) << (8 * k);
+        }
+        *word = acc;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pack_lit_row_matches_predicate() {
+        let w = 2136usize; // not a multiple of 64
+        let mut state = 0x2545_f491_4f6c_dd1du64;
+        let mut next = move || {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            state
+        };
+        let thr: Vec<f32> = (0..w).map(|c| c as f32 * 0.5).collect();
+        let mut row: Vec<f32> = (0..w)
+            .map(|c| c as f32 * 0.5 + (next() % 5) as f32 - 2.0)
+            .collect();
+        // Non-finite values must never be lit, whatever the threshold.
+        row[3] = f32::NAN;
+        row[64] = f32::INFINITY;
+        row[65] = f32::NEG_INFINITY;
+        row[w - 1] = f32::INFINITY;
+        let mut words = vec![u64::MAX; w.div_ceil(64)];
+        pack_lit_row(&row, &thr, &mut words);
+        for c in 0..w {
+            let expect = row[c].is_finite() && row[c] > thr[c];
+            let got = words[c / 64] >> (c % 64) & 1 == 1;
+            assert_eq!(got, expect, "column {c}");
+        }
+        // Padding bits are zero.
+        assert_eq!(words[w / 64] >> (w % 64), 0);
+    }
 }

--- a/src/centroid_extraction/mod.rs
+++ b/src/centroid_extraction/mod.rs
@@ -24,9 +24,11 @@
 //!   functions above stay the default and the right choice for calibration.
 //!
 //! With the `parallel` feature, the dominant local-background stage and the
-//! full-image element-wise maps of the connected-component path run
-//! multi-threaded via rayon; results are bit-identical to the sequential
-//! build. (The fast single-pass path is sequential.)
+//! full-image element-wise maps of the connected-component path, and the
+//! background grid + detection bit mask of the fast path, run multi-threaded
+//! via rayon; results are bit-identical to the sequential build. (The fast
+//! path's run sweep over the mask is sequential — it is proportional to the
+//! number of runs, not pixels.)
 //!
 //! # Example
 //!
@@ -357,7 +359,9 @@ fn check_pixel_len(len: usize, width: u32, height: u32) -> Result<()> {
 /// Scope is deliberately narrow. Profiling (`smrecording.fits`, 2.1 Mpix) shows
 /// `estimate_local_background` is ~60% of extraction wall-clock; the per-blob
 /// centroid loop is ~2% and connected-component labeling lives in numeris and
-/// is sequential there, so neither is parallelized here.
+/// is sequential there, so neither is parallelized here. The fast path
+/// parallelizes its background grid (one task per block row) and its
+/// detection bit mask (16-row chunks); its run sweep stays sequential.
 pub(super) mod par {
     #[cfg(feature = "parallel")]
     use rayon::prelude::*;
@@ -379,8 +383,8 @@ pub(super) mod par {
         (0..n).map(f).collect()
     }
 
-    /// Apply `f(i, chunk)` to each disjoint `chunk_len`-sized chunk of `buf`.
-    /// `buf.len()` must be a multiple of `chunk_len` (one chunk per image row).
+    /// Apply `f(i, chunk)` to each disjoint `chunk_len`-sized chunk of `buf`
+    /// (one or more image rows per chunk; the last chunk may be shorter).
     #[cfg(feature = "parallel")]
     pub fn for_each_chunk_mut<T, F>(buf: &mut [T], chunk_len: usize, f: F)
     where
@@ -609,20 +613,13 @@ impl BackgroundGrid {
     }
 
     /// Blend one grid row for `row_params(row)` into `out` (length `nx`) —
-    /// hoists the row-constant half of the interpolation out of per-pixel
-    /// sweeps; combine with [`Self::lerp_in_row`].
+    /// hoists the row-constant half of the interpolation out of per-row
+    /// passes; combine with [`Self::blend_columns`].
     #[inline]
     pub(super) fn blend_row(&self, (by0, by1, fy): (usize, usize, f32), out: &mut [f32]) {
         for (bx, g) in out.iter_mut().enumerate() {
             *g = self.grid[by0 * self.nx + bx] * (1.0 - fy) + self.grid[by1 * self.nx + bx] * fy;
         }
-    }
-
-    /// Background value at column `x` from a [`Self::blend_row`] result.
-    #[inline]
-    pub(super) fn lerp_in_row(&self, row_blend: &[f32], x: usize) -> f32 {
-        let (bx0, bx1, fx) = self.col_params(x);
-        row_blend[bx0] * (1.0 - fx) + row_blend[bx1] * fx
     }
 
     /// Column half of the interpolation for a whole row: with `row_blend`

--- a/src/centroid_extraction/mod.rs
+++ b/src/centroid_extraction/mod.rs
@@ -315,15 +315,27 @@ fn median_f32(values: &mut [f32]) -> f32 {
 /// and truncate to the configured maximum. Shared tail of both extraction
 /// paths.
 fn sort_and_truncate_by_mass(centroids: &mut Vec<Centroid>, max_centroids: Option<usize>) {
-    centroids.sort_by(|a, b| {
-        b.mass
-            .unwrap_or(0.0)
-            .partial_cmp(&a.mass.unwrap_or(0.0))
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
+    // Sort (mass, original index) keys rather than the centroids themselves:
+    // the key `(mass desc, index asc)` is a strict total order, so an
+    // unstable sort of 8-byte keys reproduces exactly the order a stable
+    // descending-mass sort would give — at roughly half the cost on dense
+    // frames with tens of thousands of detections. Both extraction paths
+    // emit `mass` as `Some(m as f32)` with `m > 0.0` in f64 (or `None`,
+    // ranked as 0.0): never NaN and never -0.0, so `total_cmp` agrees with
+    // `partial_cmp` on every key present.
+    let mut keys: Vec<(f32, u32)> = centroids
+        .iter()
+        .enumerate()
+        .map(|(i, c)| (c.mass.unwrap_or(0.0), i as u32))
+        .collect();
+    keys.sort_unstable_by(|a, b| b.0.total_cmp(&a.0).then(a.1.cmp(&b.1)));
     if let Some(max) = max_centroids {
-        centroids.truncate(max);
+        keys.truncate(max);
     }
+    *centroids = keys
+        .iter()
+        .map(|&(_, i)| centroids[i as usize].clone())
+        .collect();
 }
 
 /// Validate that a raw pixel buffer matches the claimed dimensions.
@@ -520,49 +532,56 @@ impl BackgroundGrid {
         let nx = w.div_ceil(block);
         let ny = h.div_ceil(block);
 
-        // (median, Σresidual², n_below) per block; blocks are independent and
-        // each writes its own slot, so this maps in parallel.
-        let per_block: Vec<(f32, f64, usize)> = par::map_indices(nx * ny, |bi| {
-            let bx = bi % nx;
-            let by = bi / nx;
-            let x0 = bx * block;
+        // (median, Σresidual², n_below) per block, one task per block row.
+        // Each block row walks its sampled image rows once, left to right
+        // across all its blocks (forward streaming rather than a strided
+        // gather per block); each block still receives its samples in the
+        // same y-then-x order, so medians and residual sums are unchanged.
+        let per_block_row: Vec<Vec<(f32, f64, usize)>> = par::map_indices(ny, |by| {
             let y0 = by * block;
-            let x1 = (x0 + block).min(w);
             let y1 = (y0 + block).min(h);
-
-            let mut vals: Vec<f32> = Vec::with_capacity((block / stride + 1).pow(2));
+            let cap = (block / stride + 1).pow(2);
+            let mut vals: Vec<Vec<f32>> = (0..nx).map(|_| Vec::with_capacity(cap)).collect();
             let mut y = y0;
             let mut phase = 0usize;
             while y < y1 {
-                let row = y * w;
-                let mut x = x0 + phase;
-                while x < x1 {
-                    let v = pixels[row + x];
-                    if v.is_finite() {
-                        vals.push(v);
+                let row = &pixels[y * w..(y + 1) * w];
+                for (bx, block_vals) in vals.iter_mut().enumerate() {
+                    let x0 = bx * block;
+                    let x1 = (x0 + block).min(w);
+                    let mut x = x0 + phase;
+                    while x < x1 {
+                        let v = row[x];
+                        if v.is_finite() {
+                            block_vals.push(v);
+                        }
+                        x += stride;
                     }
-                    x += stride;
                 }
                 phase = (phase + 1) % stride;
                 y += stride;
             }
-            let median = midpoint_f32(&mut vals);
-            let mut sq = 0.0_f64;
-            let mut n = 0usize;
-            for &v in &vals {
-                if v <= median {
-                    let d = (v - median) as f64;
-                    sq += d * d;
-                    n += 1;
-                }
-            }
-            (median, sq, n)
+            vals.iter_mut()
+                .map(|block_vals| {
+                    let median = midpoint_f32(block_vals);
+                    let mut sq = 0.0_f64;
+                    let mut n = 0usize;
+                    for &v in block_vals.iter() {
+                        if v <= median {
+                            let d = (v - median) as f64;
+                            sq += d * d;
+                            n += 1;
+                        }
+                    }
+                    (median, sq, n)
+                })
+                .collect()
         });
 
-        let grid: Vec<f32> = per_block.iter().map(|&(m, _, _)| m).collect();
-        let (sq_sum, n_sum) = per_block
-            .iter()
-            .fold((0.0_f64, 0usize), |(s, n), &(_, sq, k)| (s + sq, n + k));
+        let per_block = per_block_row.iter().flatten();
+        let grid: Vec<f32> = per_block.clone().map(|&(m, _, _)| m).collect();
+        let (sq_sum, n_sum) =
+            per_block.fold((0.0_f64, 0usize), |(s, n), &(_, sq, k)| (s + sq, n + k));
         let sigma = if n_sum > 0 {
             (sq_sum / n_sum as f64).sqrt() as f32
         } else {

--- a/src/centroid_extraction/mod.rs
+++ b/src/centroid_extraction/mod.rs
@@ -450,6 +450,53 @@ pub(super) struct BackgroundGrid {
     ny: usize,
     block: usize,
     stride: usize,
+    /// Row-independent half of the interpolation for every image column.
+    cols: ColPlan,
+}
+
+/// Per-column interpolation parameters of a [`BackgroundGrid`] for a `w`-wide
+/// image — the row-independent half of the bilinear blend, computed once with
+/// the same [`col_params`] arithmetic the per-pixel accessors use and grouped
+/// into segments of constant `(bx0, bx1)`, so blending a whole row is a
+/// straight multiply-add loop with no per-pixel divide / floor / clamp.
+/// See [`BackgroundGrid::blend_columns`].
+struct ColPlan {
+    /// Column blend weight `fx` and its complement `1 - fx`.
+    fx: Vec<f32>,
+    omfx: Vec<f32>,
+    /// `(c_start, c_end_exclusive, bx0, bx1)` — maximal column ranges that
+    /// share the same pair of grid columns.
+    segs: Vec<(usize, usize, usize, usize)>,
+}
+
+impl ColPlan {
+    fn new(nx: usize, block: usize, w: usize) -> Self {
+        let mut fx = Vec::with_capacity(w);
+        let mut omfx = Vec::with_capacity(w);
+        let mut segs: Vec<(usize, usize, usize, usize)> = Vec::new();
+        for c in 0..w {
+            let (bx0, bx1, f) = col_params(nx, block, c);
+            fx.push(f);
+            omfx.push(1.0 - f);
+            match segs.last_mut() {
+                Some(seg) if seg.2 == bx0 && seg.3 == bx1 => seg.1 = c + 1,
+                _ => segs.push((c, c + 1, bx0, bx1)),
+            }
+        }
+        Self { fx, omfx, segs }
+    }
+}
+
+/// Column-constant part of the interpolation for image column `x`: the two
+/// grid columns to blend and the (unclamped — extrapolating) blend weight.
+#[inline]
+fn col_params(nx: usize, block: usize, x: usize) -> (usize, usize, f32) {
+    if nx == 1 {
+        return (0, 0, 0.0);
+    }
+    let bf = (x as f32 - block as f32 / 2.0) / block as f32;
+    let bx0 = (bf.floor() as isize).clamp(0, nx as isize - 2) as usize;
+    (bx0, bx0 + 1, bf - bx0 as f32)
 }
 
 impl BackgroundGrid {
@@ -525,6 +572,7 @@ impl BackgroundGrid {
                 ny,
                 block,
                 stride,
+                cols: ColPlan::new(nx, block, w),
             },
             sigma,
         )
@@ -577,14 +625,50 @@ impl BackgroundGrid {
         row_blend[bx0] * (1.0 - fx) + row_blend[bx1] * fx
     }
 
+    /// Column half of the interpolation for a whole row: with `row_blend`
+    /// from [`Self::blend_row`], for every image column `c`
+    ///
+    /// ```text
+    /// out[c] = map(row_blend[bx0] * (1 - fx) + row_blend[bx1] * fx)
+    /// ```
+    ///
+    /// with `(bx0, bx1, fx) = col_params(c)` — the same expression and
+    /// operation order as [`Self::value_at`] (which is exactly `blend_row`
+    /// followed by this column blend), so `map = |v| v` reproduces
+    /// `value_at(c, rp)` bit for bit, but the per-column divide / floor /
+    /// clamp is hoisted into the column plan built once by [`Self::build`].
+    /// `out.len()` must equal the image width given to `build`. `map` is
+    /// applied to each blended value (`|v| v + k·σ` for a detection
+    /// threshold, see [`Self::threshold_row`]).
+    #[inline]
+    pub(super) fn blend_columns(
+        &self,
+        row_blend: &[f32],
+        out: &mut [f32],
+        map: impl Fn(f32) -> f32,
+    ) {
+        debug_assert_eq!(out.len(), self.cols.fx.len());
+        for &(c0, c1, bx0, bx1) in &self.cols.segs {
+            let (g0, g1) = (row_blend[bx0], row_blend[bx1]);
+            let fx = &self.cols.fx[c0..c1];
+            let omfx = &self.cols.omfx[c0..c1];
+            for ((o, &f), &omf) in out[c0..c1].iter_mut().zip(fx).zip(omfx) {
+                *o = map(g0 * omf + g1 * f);
+            }
+        }
+    }
+
+    /// Detection threshold of every column of the row blended into
+    /// `row_blend`: `out[c] = value_at(c, rp) + k_sigma`, bit for bit (see
+    /// [`Self::blend_columns`]).
+    #[inline]
+    pub(super) fn threshold_row(&self, row_blend: &[f32], k_sigma: f32, out: &mut [f32]) {
+        self.blend_columns(row_blend, out, |v| v + k_sigma);
+    }
+
     #[inline]
     fn col_params(&self, x: usize) -> (usize, usize, f32) {
-        if self.nx == 1 {
-            return (0, 0, 0.0);
-        }
-        let bf = (x as f32 - self.block as f32 / 2.0) / self.block as f32;
-        let bx0 = (bf.floor() as isize).clamp(0, self.nx as isize - 2) as usize;
-        (bx0, bx0 + 1, bf - bx0 as f32)
+        col_params(self.nx, self.block, x)
     }
 }
 

--- a/src/centroid_extraction/runs.rs
+++ b/src/centroid_extraction/runs.rs
@@ -1,7 +1,10 @@
 //! Run-length connected-region core shared by both extraction paths.
 //!
-//! A single raster sweep turns an arbitrary per-pixel `lit` predicate into
+//! A single raster sweep turns an arbitrary per-pixel `lit` predicate
+//! ([`sweep_runs`]) — or a packed detection bit mask ([`sweep_runs_mask`]),
+//! where work scales with the number of runs rather than pixels — into
 //! horizontal runs, merging 8-connected runs across rows with union-find.
+//! Both produce identical [`RunRegions`] for the same lit set.
 //! Region payloads live with the callers: the fast path computes moments
 //! from the run lists in a post-pass (lit pixels are ≪1% of the image, so
 //! the second touch is nearly free), while the quality path runs its
@@ -11,7 +14,7 @@
 //! test in every downstream stage.
 
 /// A horizontal run of lit pixels: columns `c0..=c1` of `row`.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) struct Run {
     pub row: u32,
     pub c0: u32,
@@ -25,7 +28,7 @@ impl Run {
     }
 }
 
-/// Result of [`sweep_runs`]: the runs in creation (row-major) order, each
+/// Result of [`sweep_runs`] / [`sweep_runs_mask`]: the runs in creation (row-major) order, each
 /// run's dense region id, and the region count. Region ids are assigned in
 /// order of first appearance, so iterating regions is deterministic.
 pub(super) struct RunRegions {
@@ -115,15 +118,8 @@ pub(super) fn sweep_runs(
     h: usize,
     mut lit: impl FnMut(usize, usize) -> bool,
 ) -> RunRegions {
-    // One provisional union-find label per run; label id == run index.
-    let mut parents: Vec<u32> = Vec::new();
-    let mut runs: Vec<Run> = Vec::new();
-    // Runs of the previous / current row: (c0, c1, label).
-    let mut prev: Vec<(u32, u32, u32)> = Vec::new();
-    let mut cur: Vec<(u32, u32, u32)> = Vec::new();
-
+    let mut sweep = Sweep::new();
     for r in 0..h {
-        cur.clear();
         let mut start: Option<usize> = None;
         for c in 0..w {
             if lit(r, c) {
@@ -131,68 +127,180 @@ pub(super) fn sweep_runs(
                     start = Some(c);
                 }
             } else if let Some(s) = start.take() {
-                let label = runs.len() as u32;
-                parents.push(label);
-                runs.push(Run {
-                    row: r as u32,
-                    c0: s as u32,
-                    c1: (c - 1) as u32,
-                });
-                cur.push((s as u32, (c - 1) as u32, label));
+                sweep.push_run(r, s, c - 1);
             }
         }
         if let Some(s) = start.take() {
-            let label = runs.len() as u32;
-            parents.push(label);
-            runs.push(Run {
-                row: r as u32,
-                c0: s as u32,
-                c1: (w - 1) as u32,
-            });
-            cur.push((s as u32, (w - 1) as u32, label));
+            sweep.push_run(r, s, w - 1);
         }
+        sweep.end_row();
+    }
+    sweep.finish()
+}
 
-        // Merge current-row runs with 8-connected previous-row runs. Both
-        // lists are column-sorted, so a two-pointer sweep finds all overlaps.
-        let (mut i, mut j) = (0usize, 0usize);
-        while i < cur.len() && j < prev.len() {
-            let (cs, ce, cl) = cur[i];
-            let (ps, pe, pl) = prev[j];
-            if ce + 1 < ps {
-                i += 1; // current run ends left of (and not adjacent to) prev
-            } else if pe + 1 < cs {
-                j += 1; // prev run ends left of current
+/// Run-length 8-connected labeling over a packed bit mask.
+///
+/// `mask` holds `words_per_row` `u64` words per image row (`h` rows, row
+/// `r` at `mask[r * words_per_row..]`); column `c` is lit when bit `c % 64`
+/// of word `c / 64` is set. Bits at or beyond `w` in the last word of a row
+/// are ignored, so `w` need not be a multiple of 64. Runs are read off the
+/// words with `trailing_zeros` / `trailing_ones` (a run that reaches the top
+/// bit of a word is carried into the next), so the cost is proportional to
+/// the number of runs, not pixels. Yields exactly the [`RunRegions`] that
+/// [`sweep_runs`] gives for the same lit set — runs in row-major order,
+/// same connectivity, same first-appearance region ids.
+pub(super) fn sweep_runs_mask(
+    w: usize,
+    h: usize,
+    words_per_row: usize,
+    mask: &[u64],
+) -> RunRegions {
+    let n_words = w.div_ceil(64);
+    assert!(
+        words_per_row >= n_words && mask.len() >= words_per_row * h,
+        "bit mask too small for a {w}x{h} image ({words_per_row} words/row, {} words)",
+        mask.len()
+    );
+    // Clears the padding bits of a row's last word (no-op when 64 | w).
+    let tail_mask = if w.is_multiple_of(64) {
+        u64::MAX
+    } else {
+        (1u64 << (w % 64)) - 1
+    };
+
+    let mut sweep = Sweep::new();
+    for (r, row) in mask.chunks_exact(words_per_row).take(h).enumerate() {
+        // Start column of a run that reached the top bit of the previous word.
+        let mut open: Option<usize> = None;
+        for (wi, &word) in row[..n_words].iter().enumerate() {
+            let base = wi * 64;
+            let mut bits = if wi + 1 == n_words {
+                word & tail_mask
             } else {
-                union(&mut parents, cl, pl);
-                if ce < pe {
-                    i += 1;
-                } else {
-                    j += 1;
+                word
+            };
+            // Bits of this word already consumed (shifted out of `bits`).
+            let mut pos = 0u32;
+            if let Some(s) = open {
+                let ones = bits.trailing_ones();
+                if ones == 64 {
+                    continue; // whole word lit: the run stays open
                 }
+                sweep.push_run(r, s, base + ones as usize - 1);
+                open = None;
+                bits >>= ones;
+                pos = ones;
+            }
+            while bits != 0 {
+                let tz = bits.trailing_zeros();
+                bits >>= tz;
+                pos += tz;
+                let start = base + pos as usize;
+                let ones = bits.trailing_ones();
+                if pos + ones >= 64 {
+                    open = Some(start); // reaches the top bit: may continue
+                    break;
+                }
+                sweep.push_run(r, start, start + ones as usize - 1);
+                bits >>= ones;
+                pos += ones;
             }
         }
-
-        std::mem::swap(&mut prev, &mut cur);
-    }
-
-    // Resolve roots and compact them to dense region ids in first-appearance
-    // (row-major) order.
-    let mut region_of_run = vec![0u32; runs.len()];
-    let mut id_of_root = vec![u32::MAX; parents.len()];
-    let mut n_regions = 0usize;
-    for (i, reg) in region_of_run.iter_mut().enumerate() {
-        let root = find(&mut parents, i as u32) as usize;
-        if id_of_root[root] == u32::MAX {
-            id_of_root[root] = n_regions as u32;
-            n_regions += 1;
+        if let Some(s) = open {
+            sweep.push_run(r, s, w - 1);
         }
-        *reg = id_of_root[root];
+        sweep.end_row();
+    }
+    sweep.finish()
+}
+
+/// Union-find state shared by the sweeps: one provisional label per run
+/// (label id == run index), rows merged with their predecessor as they
+/// complete, roots compacted to dense region ids at the end.
+struct Sweep {
+    parents: Vec<u32>,
+    runs: Vec<Run>,
+    /// Runs of the previous / current row: (c0, c1, label).
+    prev: Vec<(u32, u32, u32)>,
+    cur: Vec<(u32, u32, u32)>,
+}
+
+impl Sweep {
+    fn new() -> Self {
+        Self {
+            parents: Vec::new(),
+            runs: Vec::new(),
+            prev: Vec::new(),
+            cur: Vec::new(),
+        }
     }
 
-    RunRegions {
-        runs,
-        region_of_run,
-        n_regions,
+    /// Append the run `c0..=c1` of `row`. Rows must be pushed in order and
+    /// runs left to right within a row.
+    #[inline]
+    fn push_run(&mut self, row: usize, c0: usize, c1: usize) {
+        let label = self.runs.len() as u32;
+        self.parents.push(label);
+        self.runs.push(Run {
+            row: row as u32,
+            c0: c0 as u32,
+            c1: c1 as u32,
+        });
+        self.cur.push((c0 as u32, c1 as u32, label));
+    }
+
+    /// Merge the current row's runs with 8-connected runs of the previous
+    /// row, then make it the previous row.
+    fn end_row(&mut self) {
+        merge_rows(&mut self.parents, &self.cur, &self.prev);
+        std::mem::swap(&mut self.prev, &mut self.cur);
+        self.cur.clear();
+    }
+
+    /// Resolve roots and compact them to dense region ids in
+    /// first-appearance (row-major) order.
+    fn finish(self) -> RunRegions {
+        let Self {
+            mut parents, runs, ..
+        } = self;
+        let mut region_of_run = vec![0u32; runs.len()];
+        let mut id_of_root = vec![u32::MAX; parents.len()];
+        let mut n_regions = 0usize;
+        for (i, reg) in region_of_run.iter_mut().enumerate() {
+            let root = find(&mut parents, i as u32) as usize;
+            if id_of_root[root] == u32::MAX {
+                id_of_root[root] = n_regions as u32;
+                n_regions += 1;
+            }
+            *reg = id_of_root[root];
+        }
+        RunRegions {
+            runs,
+            region_of_run,
+            n_regions,
+        }
+    }
+}
+
+/// Union every current-row run with each 8-connected previous-row run. Both
+/// lists are column-sorted, so a two-pointer sweep finds all overlaps.
+fn merge_rows(parents: &mut [u32], cur: &[(u32, u32, u32)], prev: &[(u32, u32, u32)]) {
+    let (mut i, mut j) = (0usize, 0usize);
+    while i < cur.len() && j < prev.len() {
+        let (cs, ce, cl) = cur[i];
+        let (ps, pe, pl) = prev[j];
+        if ce + 1 < ps {
+            i += 1; // current run ends left of (and not adjacent to) prev
+        } else if pe + 1 < cs {
+            j += 1; // prev run ends left of current
+        } else {
+            union(parents, cl, pl);
+            if ce < pe {
+                i += 1;
+            } else {
+                j += 1;
+            }
+        }
     }
 }
 
@@ -225,14 +333,40 @@ mod tests {
         sweep_runs(w, h, |r, c| mask[r][c] != 0)
     }
 
-    #[test]
-    fn test_sweep_runs_basic() {
-        let rr = regions_of(&[
-            &[1, 1, 0, 0, 1],
-            &[0, 1, 0, 1, 0], // diagonal touch joins col-4/row-0 with col-3/row-1
-            &[0, 0, 0, 0, 0],
-            &[1, 0, 0, 0, 1],
-        ]);
+    /// Pack a byte mask into `words_per_row` words per row. Padding bits
+    /// (at or beyond `w`) and padding words are filled with garbage to
+    /// prove the sweep ignores them.
+    fn pack(mask: &[&[u8]], words_per_row: usize) -> Vec<u64> {
+        let w = mask[0].len();
+        let mut out = vec![u64::MAX; words_per_row * mask.len()];
+        for (r, row) in mask.iter().enumerate() {
+            for wi in 0..words_per_row {
+                let mut word = 0u64;
+                for b in 0..64 {
+                    let c = wi * 64 + b;
+                    let lit = if c < w { row[c] != 0 } else { (c + r) % 3 == 0 };
+                    word |= (lit as u64) << b;
+                }
+                out[r * words_per_row + wi] = word;
+            }
+        }
+        out
+    }
+
+    fn regions_of_mask(mask: &[&[u8]]) -> RunRegions {
+        let h = mask.len();
+        let w = mask[0].len();
+        let wpr = w.div_ceil(64);
+        sweep_runs_mask(w, h, wpr, &pack(mask, wpr))
+    }
+
+    fn assert_same(a: &RunRegions, b: &RunRegions) {
+        assert_eq!(a.n_regions, b.n_regions);
+        assert_eq!(a.runs, b.runs);
+        assert_eq!(a.region_of_run, b.region_of_run);
+    }
+
+    fn check_basic(rr: RunRegions) {
         assert_eq!(rr.n_regions, 4);
         let (offsets, order) = rr.group_by_region();
         // Region of the first run (top-left pair) contains 2 runs.
@@ -241,6 +375,24 @@ mod tests {
         // Total pixels across all runs.
         let total: usize = order.iter().map(|&i| rr.runs[i as usize].len()).sum();
         assert_eq!(total, 7);
+    }
+
+    const BASIC: [&[u8]; 4] = [
+        &[1, 1, 0, 0, 1],
+        &[0, 1, 0, 1, 0], // diagonal touch joins col-4/row-0 with col-3/row-1
+        &[0, 0, 0, 0, 0],
+        &[1, 0, 0, 0, 1],
+    ];
+
+    #[test]
+    fn test_sweep_runs_basic() {
+        check_basic(regions_of(&BASIC));
+    }
+
+    #[test]
+    fn test_sweep_runs_mask_basic() {
+        check_basic(regions_of_mask(&BASIC));
+        assert_same(&regions_of(&BASIC), &regions_of_mask(&BASIC));
     }
 
     #[test]
@@ -252,5 +404,87 @@ mod tests {
         let rr = regions_of(&[&[0, 0], &[0, 0]]);
         assert_eq!(rr.n_regions, 0);
         assert!(rr.runs.is_empty());
+    }
+
+    #[test]
+    fn test_sweep_runs_mask_full_row_and_empty() {
+        let rr = regions_of_mask(&[&[1, 1, 1], &[1, 1, 1]]);
+        assert_eq!(rr.n_regions, 1);
+        assert_eq!(rr.runs.len(), 2);
+
+        let rr = regions_of_mask(&[&[0, 0], &[0, 0]]);
+        assert_eq!(rr.n_regions, 0);
+        assert!(rr.runs.is_empty());
+    }
+
+    #[test]
+    fn test_sweep_runs_mask_word_boundaries() {
+        // Runs ending exactly at, starting exactly at, and spanning word
+        // boundaries; a fully lit word inside a run; runs touching the right
+        // image edge both with 64 | w and with w % 64 != 0.
+        for w in [64usize, 65, 127, 128, 129, 200] {
+            let row: Vec<u8> = (0..w)
+                .map(|c| {
+                    (c == 0
+                        || (60..=63).contains(&c)
+                        || ((64..=70).contains(&c) && w > 66)
+                        || (120..w).contains(&c)
+                        || ((30..=191).contains(&c) && w == 200)) as u8
+                })
+                .collect();
+            let blank = vec![0u8; w];
+            let mask: [&[u8]; 3] = [&row, &blank, &row];
+            assert_same(&regions_of(&mask), &regions_of_mask(&mask));
+        }
+        // Every pixel lit: one run per row spanning several words.
+        let row = vec![1u8; 300];
+        let mask: [&[u8]; 2] = [&row, &row];
+        let rr = regions_of_mask(&mask);
+        assert_same(&regions_of(&mask), &rr);
+        assert_eq!(rr.n_regions, 1);
+        assert_eq!(
+            rr.runs[0],
+            Run {
+                row: 0,
+                c0: 0,
+                c1: 299
+            }
+        );
+    }
+
+    #[test]
+    fn test_sweep_runs_mask_matches_sweep_runs_random() {
+        let mut state = 0x9e37_79b9_7f4a_7c15u64;
+        let mut next = move || {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            state
+        };
+        let sizes = [
+            (1usize, 1usize),
+            (7, 3),
+            (63, 5),
+            (64, 4),
+            (65, 6),
+            (130, 9),
+            (2136, 3),
+            (257, 40),
+        ];
+        for &(w, h) in &sizes {
+            for density in [1u64, 8, 32, 60] {
+                let rows: Vec<Vec<u8>> = (0..h)
+                    .map(|_| (0..w).map(|_| (next() % 64 < density) as u8).collect())
+                    .collect();
+                let mask: Vec<&[u8]> = rows.iter().map(|r| r.as_slice()).collect();
+                let a = regions_of(&mask);
+                let b = regions_of_mask(&mask);
+                assert_same(&a, &b);
+                // Padding words beyond `w.div_ceil(64)` are ignored too.
+                let wpr = w.div_ceil(64) + 2;
+                let c = sweep_runs_mask(w, h, wpr, &pack(&mask, wpr));
+                assert_same(&a, &c);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Root cause

Profiling `extract_centroids_fast` (`src/centroid_extraction/fast.rs`) showed ~97% of its time in the per-pixel `lit` closure handed to `runs::sweep_runs`: every pixel paid `is_finite` + `lerp_in_row` → `col_params` (an f32 divide, `floor` and `clamp`) + a branchy `Option<usize>` run state machine. The path was 25× above the single-thread streaming-read floor on a 2048² frame and not vectorizable.

## What changed

1. **Column plan + `threshold_row`** (`mod.rs`): `BackgroundGrid::build` now precomputes, once per image, the row-independent `(bx0, bx1, fx, 1−fx)` of every column with the same `col_params` arithmetic, grouped into constant-`(bx0, bx1)` segments (`ColPlan`). `BackgroundGrid::blend_columns(row_blend, out, map)` blends a whole row per segment — same expression and operation order as `value_at`, so bit-identical — and `threshold_row(row_blend, k_sigma, out)` is `blend_columns` with `|v| v + k·σ`. `blend_columns` is generic so the CCL residual pass can reuse it for its per-pixel `value_at`.
2. **Bit-mask run sweep** (`runs.rs`): `sweep_runs_mask(w, h, words_per_row, mask)` extracts runs from `u64` words with `trailing_zeros`/`trailing_ones`, carrying an open run across word boundaries and masking padding bits (`w` need not be a multiple of 64 — TESS is 2136 wide). The union-find state (`Sweep`: `push_run` / `end_row` / `finish`, plus `merge_rows`) is factored out and shared with the closure-driven `sweep_runs`, which the CCL path keeps. Region ids are identical: runs stay row-major, connectivity unchanged, first-appearance id assignment.
3. **Fast path** (`fast.rs`): per row, `blend_row` → `threshold_row` → compare into a 64-byte scratch as `(p > thr[c]) & (p < +∞)` (≡ `is_finite && p > thr`, branch-free) → pack 8 bytes to 8 bits with `wrapping_mul(0x0102_0408_1020_4080) >> 56` → `sweep_runs_mask`. The whole-image mask (h × ⌈w/64⌉ words, 512 KB at 2048²) is filled in 16-row chunks via `par::for_each_chunk_mut`, so under `parallel` the threshold pass is multi-threaded while the run sweep stays sequential (prototype V5; the strip-parallel union-find V6 was deliberately not implemented).
4. **Small**: `BackgroundGrid::build` streams each block row across its blocks (one parallel task per block row instead of per block) with identical per-block sample order and residual fold order; `sort_and_truncate_by_mass` sorts `(mass desc, index asc)` keys with an unstable sort — a strict total order, so the result equals the stable sort's; masses on both paths are `Some(m as f32)` with `m > 0` in f64 or `None` (→ 0.0), never NaN / −0.0, so `total_cmp` agrees with `partial_cmp`.

`lerp_in_row` is removed (its only caller was the closure). No changes to `ccl.rs`, `python/`, or numeris.

## Timings

Apple M3 (8 cores), `--release` (opt-level 3, thin LTO, cgu=1), minimum of 30 reps, full `extract_centroids_fast` call. Synthetic fields: 500 DN background + gradient, σ=8 noise, PSF σ=1.3 px. Real frames from `data/`.

| Field | Mpix | before serial | after serial | speedup | before parallel | after parallel | speedup |
|---|---|---|---|---|---|---|---|
| synth 2048² sparse (60 stars) | 4.19 | 7.65 ms | 1.25 ms | 6.1× | 7.29 ms | 0.42 ms | 17.5× |
| synth 2048² dense (3000) | 4.19 | 9.93 | 2.10 | 4.7× | 8.84 | 1.30 | 6.8× |
| synth 1024² sparse (30) | 1.05 | 1.87 | 0.32 | 5.9× | 1.86 | 0.13 | 14.6× |
| synth 1920×1080 sparse (40) | 2.07 | 3.66 | 0.62 | 5.9× | 3.61 | 0.22 | 16.5× |
| real smrecording.fits 1920×1080 u16 | 2.07 | 3.66 | 0.64 | 5.7× | 3.66 | 0.24 | 15.1× |
| real SkyView cygnus 2048² (137k regions) | 4.19 | 16.44 | 6.21 | 2.6× | 16.36 | 5.26 | 3.1× |
| real TESS s01 2136×2078 (35k regions) | 4.44 | 16.22 | 5.73 | 2.8× | 15.99 | 4.86 | 3.3× |

Dense survey frames are now dominated by the per-region moments/`finish_region` pass and the sort, not the sweep.

## Bit-identity verification

A golden dump (every centroid's `x`/`y`/`mass`/`cov` bits, `num_blobs_raw`, `background_mean`/`background_sigma`/`threshold` bits) for all 7 fields was taken from the unchanged code, then regenerated after the changes from a harness pointed at this branch: `cmp` reports identical files for the serial build and for `--features parallel` (and serial == parallel). Region ids and run order are also covered by the new unit test comparing `sweep_runs` and `sweep_runs_mask` on random images.

## Tests

- `runs.rs`: `sweep_runs` tests duplicated for `sweep_runs_mask`; word-boundary cases (runs ending/starting/spanning words, fully lit words, right edge with and without 64 | w, padding words); random-image equivalence with `sweep_runs` at widths 1, 7, 63, 64, 65, 130, 257, 2136 and four densities.
- `fast.rs`: `pack_lit_row` vs the `is_finite && p > thr` predicate at width 2136 with NaN/±∞ pixels and padding-bit check.
- `cargo test`, `cargo test --features image`, `cargo test --features image,parallel`, `cargo test --test tess_solve_test --features image` (includes the fast-vs-CCL cross-match): all pass. `cargo fmt --all --check` and `cargo clippy --all-targets --all-features -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q27Wdq3SRmb8w612idHkRw
