### PR TITLE
chore(python): numeris 0.5.19 in lockstep with the root crate

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -14,7 +14,7 @@ pyo3 = { version = "0.29.2", features = ["extension-module"] }
 numpy = "0.29.0"
 postcard = { version = "1.0", features = ["alloc"] }
 serde = { version = "1.0", features = ["derive"] }
-numeris = { version = "0.5.17", features = ["std"] }
+numeris = { version = "0.5.19", features = ["std"] }
 
 [build-dependencies]
 pyo3-build-config = "0.29.2"


### PR DESCRIPTION
Root `Cargo.toml` moved to numeris 0.5.19 in #54 (for `gaussian_blur_into`); this bumps the PyO3 extension crate's own dependency to match so the two stay in lockstep. No code change; `Cargo.lock` already resolves to 0.5.19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q27Wdq3SRmb8w612idHkRw