### PR TITLE
release: 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Only recent releases are listed. Older entries are in this file's git history (`git show vX.Y.Z:CHANGELOG.md`). Full detail for each change lives in the linked PR.
 
-## Unreleased
+## 0.12.0 - 2026-08-30
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,7 +942,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tetra3"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "image",
  "numeris",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "tetra3-python"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "numeris",
  "numpy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = [
     "pattern-recognition",
 ]
 name = "tetra3"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Rust implementation of Tetra3: Fast and robust star plate solver"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tetra3rs"
-version = "0.11.0"
+version = "0.12.0"
 description = "Fast star plate solver written in Rust"
 requires-python = ">=3.10"
 dependencies = ["numpy", "gaia-catalog<1.0"]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tetra3-python"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
Bumps `Cargo.toml`, root `pyproject.toml`, and `python/Cargo.toml` to 0.12.0 in lockstep and dates the CHANGELOG section (#52–#55: centroid-extraction perf pass — fast path 6×/17×, CCL path 1.8×/3.5× — and numeris 0.5.19).

After merge: `git tag v0.12.0 && git push origin v0.12.0` (PyPI via publish.yml) and `cargo publish -p tetra3` (manual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q27Wdq3SRmb8w612idHkRw