### PR TITLE
fix(solver): polar cone-query coverage, re-verify scale, trig-free WCS refine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Only recent releases are listed. Older entries are in this file's git history (`git show vX.Y.Z:CHANGELOG.md`). Full detail for each change lives in the linked PR.
 
+## Unreleased
+
+### Changed
+
+- WCS refinement projects catalog stars with the tangent-plane basis at CRVAL (dot products, as Phase-D re-association already did) instead of decoding each matched star to RA/Dec and evaluating per-star trig every pass; `wcs_refine` 16.9 → 12.2 µs per solve on the profiler field (mean solve 50 → 41 µs), results unchanged within f64 rounding. ([#59](https://github.com/ssmichael1/tetra3rs/pull/59))
+
+### Fixed
+
+- `StarCatalog` cone queries sized each latitude bin's RA span from the bin center, missing most stars within a few degrees of either pole (dec 88°: ~65% missed; dec 89.5°: ~85%) — verification, tracking, WCS re-association, and database generation all share the query, so polar fields solved with half the matches or not at all. The span is now bounded at the bin's polar edge; brute-force regression test added. Regenerate databases built before this fix. ([#59](https://github.com/ssmichael1/tetra3rs/pull/59))
+- The post-refinement acceptance re-verify reused verification vectors built at the swept FOV whenever the measured-FOV rebuild was skipped, so on wide frames (≳3000 px) true edge matches fell outside the tightened 2.5 px radius floor and weakened the acceptance statistic; the re-verify now always uses vectors at the refined scale. ([#59](https://github.com/ssmichael1/tetra3rs/pull/59))
+
 ## 0.12.0 - 2026-08-30
 
 ### Changed

--- a/examples/profile_solve.rs
+++ b/examples/profile_solve.rs
@@ -347,7 +347,6 @@ fn main() {
         const WCS_COUNTS: &[&str] = &[
             bk::WCS_OUTER,
             bk::WCS_INNER,
-            bk::WCS_RADEC,
             bk::WCS_REASSOC_CALL,
             bk::WCS_REASSOC_STARS,
         ];
@@ -386,11 +385,6 @@ fn main() {
                     n as f64 / sets.len() as f64
                 );
             }
-            let radec = get(bk::WCS_RADEC).1;
-            println!(
-                "    → sv_to_radec (atan2+asin) called {:.0}×/solve; tan_project similar — prime cache targets",
-                radec as f64 / sets.len() as f64
-            );
         }
 
         // The key question for the N×N precompute decision:

--- a/src/solver/profiling.rs
+++ b/src/solver/profiling.rs
@@ -19,8 +19,8 @@
 //! - **Threading:** accumulators are `thread_local`, so [`snapshot`] reports only
 //!   the calling thread. A solve is single-threaded today; if solves are ever run
 //!   in parallel, per-thread results would need to be merged by the caller.
-//! - **Observer cost:** counting inside very hot leaves (e.g. `wcs_radec` fires
-//!   ~1000×/solve) adds a few ns per call via the `RefCell` borrow, which
+//! - **Observer cost:** counting inside very hot leaves (hundreds of calls per
+//!   solve) adds a few ns per call via the `RefCell` borrow, which
 //!   slightly inflates the *absolute* timing of the enclosing span. Counts
 //!   themselves are exact; relative splits from `timed!` spans around larger
 //!   blocks are reliable.
@@ -67,8 +67,6 @@ pub mod buckets {
     pub const WCS_OUTER: &str = "wcs_outer";
     /// Number of inner least-squares iterations.
     pub const WCS_INNER: &str = "wcs_inner";
-    /// `sv_to_radec` (atan2 + asin) invocations.
-    pub const WCS_RADEC: &str = "wcs_radec";
     /// Phase-D re-association: catalog cone query (timed).
     pub const WCS_REASSOC_QUERY: &str = "wcs_reassoc_query";
     /// Phase-D re-association: project nearby catalog stars to pixels (timed).

--- a/src/solver/solve.rs
+++ b/src/solver/solve.rs
@@ -319,6 +319,10 @@ impl SolverDatabase {
         // measured FOV (see the rebuild step in the candidate loop). Reused
         // across candidates to avoid per-candidate allocation.
         let mut rebuilt_vectors: Vec<[f32; 3]> = Vec::new();
+        // Scratch for the post-refinement re-verify (see the acceptance test
+        // in the candidate loop). Separate from `rebuilt_vectors` because
+        // `working_vectors` may still borrow that one.
+        let mut reverify_buf: Vec<[f32; 3]> = Vec::new();
 
         // Matching working buffers, held across the candidate loop so
         // `verify_attitude`/`find_centroid_matches` reuse them (see their
@@ -745,6 +749,7 @@ impl SolverDatabase {
                     // match measures the true scale, and the model's f is only
                     // a search seed here. Fewer than 4 surviving matches → try
                     // next candidate.
+                    let ps_fov = pixel_scale_from_fov(config.image_width(), fov as f64);
                     let Some(mut result) = self.refine_and_finalize(
                         &rotation_matrix,
                         &current_matches,
@@ -754,7 +759,7 @@ impl SolverDatabase {
                         config,
                         parity_flip,
                         fov,
-                        pixel_scale_from_fov(config.image_width(), fov as f64),
+                        ps_fov,
                         match_centroid_count,
                         4,
                         prob_mismatch,
@@ -797,13 +802,35 @@ impl SolverDatabase {
                     // lucky false one. Floored at 2.5 px (the refinement's own
                     // adaptive-radius floor) and never looser than the search
                     // radius.
+                    // The refinement was locked to the candidate's measured
+                    // scale (`ps_fov`), but `working_vectors` still sit at the
+                    // *swept* scale when the rebuild above was skipped
+                    // (mismatch ≤ 0.25·match_radius). That slack is harmless
+                    // at the coarse search radius, not at the tightened
+                    // re-verify radius below (floored at 2.5 px): the edge
+                    // residual ε·r reaches ~7 px on a 4096 px frame, silently
+                    // dropping true edge matches from the acceptance
+                    // statistic. Rebuild at `ps_fov` unless that already
+                    // happened — only pre-gated candidates reach here, so the
+                    // cost is negligible.
+                    let reverify_vectors: &[[f32; 3]] =
+                        if rebuild {
+                            working_vectors
+                        } else {
+                            let sign = if parity_flip { -1.0f32 } else { 1.0 };
+                            reverify_buf.clear();
+                            reverify_buf.extend(sorted_indices.iter().map(|&i| {
+                                unit_vector_from_pixels(&centroids[i], ps_fov as f32, sign)
+                            }));
+                            &reverify_buf
+                        };
                     let ps_refined = (1.0 / result.camera_model.focal_length_px) as f32;
                     let refined_radius = (5.0 * result.rmse_rad)
                         .max(2.5 * ps_refined)
                         .min(config.match_radius * result.fov_rad);
                     let (refined_matches, p_refined) = self.verify_attitude(
                         &refined_rotation,
-                        working_vectors,
+                        reverify_vectors,
                         match_centroid_count,
                         result.fov_rad,
                         config,

--- a/src/solver/wcs_refine.rs
+++ b/src/solver/wcs_refine.rs
@@ -207,52 +207,34 @@ fn predict_tanplane(px: f64, py: f64, cos_t: f64, sin_t: f64, ps: f64) -> (f64, 
     (xi, eta)
 }
 
-/// Precomputed per-star projection inputs: right ascension plus the sine and
-/// cosine of declination. Decoded once from the ICRS unit vector and reused
-/// across every refinement pass (the `atan2`/`asin`/`sin`/`cos` would otherwise
-/// be recomputed for the same star on every iteration).
-#[derive(Clone, Copy)]
-struct StarRaDec {
-    ra: f64,
-    sin_dec: f64,
-    cos_dec: f64,
-}
+/// Tangent-plane basis at CRVAL, `[e_ξ, e_η, boresight]` in ICRS — the
+/// camera rows of [`camera_rows_f64`] at θ = 0. Built once per fit pass
+/// (CRVAL moves between passes) and shared by every star in the pass.
+type TanBasis = [[f64; 3]; 3];
 
-/// Decode a catalog star's ICRS unit vector into [`StarRaDec`].
 #[inline]
-fn star_radec(sv: &[f32; 3]) -> StarRaDec {
-    #[cfg(feature = "profile")]
-    profiling::count(buckets::WCS_RADEC, 1);
-    let ra = (sv[1] as f64).atan2(sv[0] as f64);
-    let dec = (sv[2] as f64).asin();
-    StarRaDec {
-        ra,
-        sin_dec: dec.sin(),
-        cos_dec: dec.cos(),
-    }
+fn tan_basis(crval_ra: f64, crval_dec: f64) -> TanBasis {
+    camera_rows_f64(0.0, crval_ra, crval_dec)
 }
 
-/// TAN projection from precomputed star coords and precomputed CRVAL sin/cos.
+/// TAN projection of a catalog unit vector onto the tangent plane spanned by
+/// `basis` (see [`tan_basis`]).
 ///
-/// Equivalent to [`tan_project`] but takes a [`StarRaDec`] (star dec sin/cos
-/// already known) and the CRVAL declination sin/cos hoisted out of the per-star
-/// loop, leaving only `cos(da)`/`sin(da)` to compute per call.
+/// Equivalent to [`tan_project`] with no per-star transcendentals: for a unit
+/// vector `v`, `v·boresight` is the gnomonic denominator and `(v·e_ξ, v·e_η)`
+/// its numerators (Calabretta & Greisen 2002, §5.1.1, in Cartesian form).
+/// This is the same math Phase-D re-association already uses; it replaces the
+/// former per-star `atan2`/`asin`/`sin`/`cos` decode plus per-pass `cos(Δα)`/
+/// `sin(Δα)`. Returns `None` for a star on or behind the tangent plane.
 #[inline]
-fn tan_project_pre(
-    s: &StarRaDec,
-    crval_ra: f64,
-    sin_dec0: f64,
-    cos_dec0: f64,
-) -> Option<(f64, f64)> {
-    let da = s.ra - crval_ra;
-    let cos_da = da.cos();
-    let denom = s.sin_dec * sin_dec0 + s.cos_dec * cos_dec0 * cos_da;
+fn tan_project_vec(sv: &[f32; 3], basis: &TanBasis) -> Option<(f64, f64)> {
+    let v = [sv[0] as f64, sv[1] as f64, sv[2] as f64];
+    let dot = |r: &[f64; 3]| r[0] * v[0] + r[1] * v[1] + r[2] * v[2];
+    let denom = dot(&basis[2]);
     if denom <= 1e-12 {
         return None;
     }
-    let xi = s.cos_dec * da.sin() / denom;
-    let eta = (s.sin_dec * cos_dec0 - s.cos_dec * sin_dec0 * cos_da) / denom;
-    Some((xi, eta))
+    Some((dot(&basis[0]) / denom, dot(&basis[1]) / denom))
 }
 
 /// Accumulate one matched star's contribution to the 3-parameter
@@ -366,7 +348,7 @@ fn mad_clip_matches(
 /// pairs; matches whose star projects behind the tangent plane are skipped.
 fn compute_residuals(
     matches: &[(usize, usize)],
-    match_radec: &[StarRaDec],
+    star_vectors: &[[f32; 3]],
     centroids_px: &[(f64, f64)],
     theta: f64,
     crval_ra: f64,
@@ -375,14 +357,11 @@ fn compute_residuals(
 ) -> Vec<(usize, f64)> {
     let cos_t = theta.cos();
     let sin_t = theta.sin();
-    let sin_dec0 = crval_dec.sin();
-    let cos_dec0 = crval_dec.cos();
+    let basis = tan_basis(crval_ra, crval_dec);
 
     let mut residuals: Vec<(usize, f64)> = Vec::with_capacity(matches.len());
-    for (match_idx, &(cent_idx, _)) in matches.iter().enumerate() {
-        if let Some((xi_cat, eta_cat)) =
-            tan_project_pre(&match_radec[match_idx], crval_ra, sin_dec0, cos_dec0)
-        {
+    for (match_idx, &(cent_idx, cat_idx)) in matches.iter().enumerate() {
+        if let Some((xi_cat, eta_cat)) = tan_project_vec(&star_vectors[cat_idx], &basis) {
             let (px, py) = centroids_px[cent_idx];
             let (xi_pred, eta_pred) = predict_tanplane(px, py, cos_t, sin_t, ps);
             let dxi = xi_pred - xi_cat;
@@ -400,7 +379,7 @@ fn compute_residuals(
 /// equations are singular — callers skip the update / stop iterating.
 fn ls_fit_once(
     matches: &[(usize, usize)],
-    match_radec: &[StarRaDec],
+    star_vectors: &[[f32; 3]],
     centroids_px: &[(f64, f64)],
     theta: f64,
     crval_ra: f64,
@@ -409,18 +388,15 @@ fn ls_fit_once(
 ) -> Option<[f64; 3]> {
     let cos_t = theta.cos();
     let sin_t = theta.sin();
-    // CRVAL changes between passes; hoist its sin/cos out of the per-star loop.
-    let sin_dec0 = crval_dec.sin();
-    let cos_dec0 = crval_dec.cos();
+    // CRVAL changes between passes; build its tangent basis once per pass.
+    let basis = tan_basis(crval_ra, crval_dec);
 
     let mut ata = [[0.0f64; 3]; 3];
     let mut atb = [0.0f64; 3];
     let mut n_valid = 0u32;
 
-    for (i, &(cent_idx, _)) in matches.iter().enumerate() {
-        let Some((xi_cat, eta_cat)) =
-            tan_project_pre(&match_radec[i], crval_ra, sin_dec0, cos_dec0)
-        else {
+    for &(cent_idx, cat_idx) in matches {
+        let Some((xi_cat, eta_cat)) = tan_project_vec(&star_vectors[cat_idx], &basis) else {
             continue;
         };
 
@@ -573,14 +549,6 @@ pub fn wcs_refine(
     for outer_iter in 0..max_iterations {
         #[cfg(feature = "profile")]
         profiling::count(buckets::WCS_OUTER, 1);
-        // Precompute per-star (ra, sin_dec, cos_dec) for the current match set
-        // once; reused by Phase A's inner loop and Phase B. The values depend
-        // only on the star, not on θ/CRVAL.
-        let match_radec: Vec<StarRaDec> = current_matches
-            .iter()
-            .map(|&(_, cat_idx)| star_radec(&star_vectors[cat_idx]))
-            .collect();
-
         // ── Phase A: LS fit (δθ, dξ₀, dη₀) ──────────────────────────
         for inner_iter in 0..10 {
             if current_matches.len() < 3 {
@@ -591,7 +559,7 @@ pub fn wcs_refine(
 
             let Some(sol) = ls_fit_once(
                 &current_matches,
-                &match_radec,
+                star_vectors,
                 centroids_px,
                 theta,
                 crval_ra,
@@ -627,7 +595,7 @@ pub fn wcs_refine(
         // ── Phase B: Compute residuals ──────────────────────────────────
         let residuals = compute_residuals(
             &current_matches,
-            &match_radec,
+            star_vectors,
             centroids_px,
             theta,
             crval_ra,
@@ -809,13 +777,9 @@ pub fn wcs_refine(
             break;
         }
 
-        let match_radec: Vec<StarRaDec> = current_matches
-            .iter()
-            .map(|&(_, cat_idx)| star_radec(&star_vectors[cat_idx]))
-            .collect();
         let residuals = compute_residuals(
             &current_matches,
-            &match_radec,
+            star_vectors,
             centroids_px,
             theta,
             crval_ra,
@@ -843,13 +807,9 @@ pub fn wcs_refine(
         current_matches = keep;
 
         // Re-fit theta + CRVAL on the cleaned set (one LS pass)
-        let keep_radec: Vec<StarRaDec> = current_matches
-            .iter()
-            .map(|&(_, cat_idx)| star_radec(&star_vectors[cat_idx]))
-            .collect();
         if let Some(sol) = ls_fit_once(
             &current_matches,
-            &keep_radec,
+            star_vectors,
             centroids_px,
             theta,
             crval_ra,
@@ -868,13 +828,9 @@ pub fn wcs_refine(
     // exist only for the debug log below, so the sort they need is skipped
     // entirely unless DEBUG logging is enabled (this runs once per solve on the
     // profiling-dominant path).
-    let final_radec: Vec<StarRaDec> = current_matches
-        .iter()
-        .map(|&(_, cat_idx)| star_radec(&star_vectors[cat_idx]))
-        .collect();
     let mut final_residuals: Vec<f64> = compute_residuals(
         &current_matches,
-        &final_radec,
+        star_vectors,
         centroids_px,
         theta,
         crval_ra,

--- a/src/starcatalog.rs
+++ b/src/starcatalog.rs
@@ -235,9 +235,17 @@ impl StarCatalog {
 
         let mut out = Vec::new();
         for lat_bin in Self::z_bin_range(self.n_lat, z_min, z_max) {
-            let zc = -1.0 + (lat_bin as f32 + 0.5) * z_step;
-            let dec_center = zc.clamp(-1.0, 1.0).asin();
-            let cos_dec = dec_center.cos().abs().max(1e-6);
+            // Bound the RA half-span with the smallest |cos dec| anywhere in
+            // this latitude bin — its edge nearest a pole — not the bin
+            // center. Stars sit anywhere in the bin, and near the poles the
+            // span a star at the polar edge needs is many times the span at
+            // the center (a bin touching a pole needs every RA bin). Using
+            // the center silently dropped most stars within a few degrees of
+            // either pole.
+            let z_lo = -1.0 + lat_bin as f32 * z_step;
+            let z_hi = z_lo + z_step;
+            let z_edge = z_lo.abs().max(z_hi.abs()).min(1.0);
+            let cos_dec = (1.0 - z_edge * z_edge).max(0.0).sqrt().max(1e-6);
 
             let mut lon_half_span = (radius / cos_dec).min(PI);
             lon_half_span += lon_step;
@@ -590,5 +598,55 @@ mod tests {
             .query_indices_from_uvec(radec_to_uvec(deg2rad(122.0), deg2rad(30.0)), deg2rad(3.0));
 
         assert_eq!(by_radec, by_uvec);
+    }
+    /// Regression for the polar RA-span bug: every latitude bin's RA span
+    /// must be sized for its polar edge, not its center, or queries within
+    /// a few degrees of either pole miss most of their stars. Compares the
+    /// indexed query against a brute-force dot-product scan on a uniform
+    /// synthetic sky at declinations from the equator to 89.5°.
+    #[test]
+    fn cone_query_matches_brute_force_near_poles() {
+        // Deterministic xorshift64* — keeps the test dependency-free.
+        let mut state = 0x9E37_79B9_7F4A_7C15u64;
+        let mut unit = move || {
+            state ^= state >> 12;
+            state ^= state << 25;
+            state ^= state >> 27;
+            (state.wrapping_mul(0x2545_F491_4F6C_DD1D) >> 40) as f32 / (1u32 << 24) as f32
+        };
+        let stars: Vec<Star> = (0..50_000)
+            .map(|i| {
+                let z = 2.0 * unit() - 1.0;
+                Star {
+                    id: i,
+                    ra_rad: unit() * TAU,
+                    dec_rad: z.asin(),
+                    mag: 5.0,
+                }
+            })
+            .collect();
+        let catalog = StarCatalog::new(16, stars);
+
+        for dec_deg in [0.0f32, 45.0, 80.0, 85.0, 88.0, 89.5, -89.5] {
+            for radius_deg in [1.0f32, 3.0, 7.0] {
+                for ra_deg in [10.0f32, 100.0, 200.0, 300.0] {
+                    let dir = radec_to_uvec(deg2rad(ra_deg), deg2rad(dec_deg));
+                    let radius = deg2rad(radius_deg);
+                    let got = catalog.query_indices_from_uvec(dir, radius);
+                    let cos_r = radius.cos();
+                    let expected: Vec<usize> = catalog
+                        .stars
+                        .iter()
+                        .enumerate()
+                        .filter(|(_, s)| dir.dot(&s.uvec()) >= cos_r)
+                        .map(|(i, _)| i)
+                        .collect();
+                    assert_eq!(
+                        got, expected,
+                        "cone query at dec {dec_deg}°, ra {ra_deg}°, radius {radius_deg}°"
+                    );
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Three fixes from the September 2026 solver (non-image) robustness & speed review. No public API change, no version bump.

## 1. `StarCatalog` cone query missed most stars near the poles (Fixed)

**Root cause.** `query_impl` bounded each latitude bin's RA half-span with cos(dec) at the bin *center*. Stars sit anywhere in the bin, and near a pole the span a star at the polar edge needs is many times the span at the center (a bin touching the pole needs every RA bin). The span is now bounded at the bin's polar edge (`z_edge = max(|z_lo|, |z_hi|)`, `cos = sqrt(1 − z_edge²)`).

**Failure scenario.** Brute-force comparison on a uniform 200k-star sky, nside 16:

| query dec | radius | stars missed |
|---|---|---|
| 80° | 7° | first misses |
| 88° | 3° | ~65% |
| 89.5° | 3° | ~85% |

Verification, tracking, WCS re-association and database generation all share this query. On 10° synthetic fields with perfect centroids (profiler database):

| field dec | before: solved / mean matches | after: solved / mean matches |
|---|---|---|
| 30° | 100/100 / 36 | 100/100 / 36 |
| 88° | 100/100 / 18 | 100/100 / 35 |
| 89.5° | 93/100 / 12 | 100/100 / 36 |

With noisy or spurious centroids the polar failure rate would have been much higher.

**Tests.** New `cone_query_matches_brute_force_near_poles` (deterministic synthetic sky, dec 0° to ±89.5°, radii 1°/3°/7°). The pre-existing cone test only covered dec 30°.

**Note.** Databases built before this fix used the same query for cluster-busting and lattice-field star lists; regenerate them.

## 2. Post-refinement re-verify used vectors at the wrong scale (Fixed)

The acceptance re-verify reused `working_vectors`, which stay at the *swept* pixel scale when the 0.25·match_radius rebuild gate is not tripped. The refined attitude is locked to the candidate's measured scale, so the edge residual ε·r (~7 px on a 4096 px frame) exceeded the 2.5 px re-verify radius floor and dropped true edge matches from the acceptance statistic. The re-verify now rebuilds the vectors at the refined scale unless that already happened; only pre-gated candidates reach it, so the cost is nil. Not observable on the 1024 px profiler frames (edge residual < floor there).

## 3. Trig-free WCS refinement (Changed)

Phases A–C decoded every matched star to (ra, sin dec, cos dec) each outer iteration (~240 `atan2`/`asin`/`sincos` per solve) and evaluated `cos/sin(Δα)` per star per pass. They now project with the tangent-plane basis at CRVAL — `camera_rows_f64(0, α₀, δ₀)` — exactly the dot-product form Phase D already used. `StarRaDec`, `tan_project_pre` and the `wcs_radec` profiling bucket are removed.

Profiler, 1000 fields, 10° FOV, 1024 px:

| | before | after |
|---|---|---|
| `wcs_refine` per solve | 16.9 µs | 12.2 µs |
| mean solve | 50 µs | 41 µs |

## Verification

- `cargo clippy --all-targets --all-features -D warnings` clean
- unit + doc tests (69 + 10 + 4), `integration_test`, `skyview_solve_test`, `tess_solve_test` (incl. the 10-image multi-sector calibration) all pass
- Python bindings untouched (no binding code changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZ3H9bdqVtf65gw8XbSRko
