### PR TITLE
feat(solver): cap pattern-forming centroids at the brightest N (default 24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,14 @@ Only recent releases are listed. Older entries are in this file's git history (`
 
 ## Unreleased
 
+### Added
+
+- **Breaking:** `SolveConfig::pattern_checking_stars` (Python `pattern_checking_stars=`, default 24): only the brightest N well-separated centroids form 4-star patterns (fainter ones still verify), bounding a fruitless lost-in-space search at C(N, 4) patterns per FOV value — 200-detection no-match frames 28 → 8.8 ms on the profiler, and frames that thin to a 150-star pattern set no longer run to the timeout. Solved fields are unchanged (1500-field golden dump identical; SkyView/TESS suites pass; a cap of 12 lost 3/10 real SkyView fields, 20 is the minimum that passes). `u32::MAX` restores the unbounded search; < 4 fails `validate()`. Adds a field to an exhaustive struct → 0.13.0. ([#61](https://github.com/ssmichael1/tetra3rs/pull/61))
+- Profiler knob `T3_PATTERN_STARS=N`. ([#61](https://github.com/ssmichael1/tetra3rs/pull/61))
+
 ### Changed
 
+- Database generation sorts the pattern list before building the hash table, so a database is a pure function of its inputs; previously `HashSet` iteration order varied per process, changing hash-chain order and the candidates-tested divisor of `Solution.prob` between otherwise identical databases. ([#61](https://github.com/ssmichael1/tetra3rs/pull/61))
 - The lost-in-space solve is split into explicit stages — `preprocess` → `PatternSearch` (hypothesis source: FOV sweep, hash lookup, SVD, parity) → `verify_attitude` → `accept_lis_candidate` (pre-gate, refine, re-verify, correction) — with the verification vectors carrying their pixel scale (`CentroidVectors`) so a stage needing a different scale rebuilds instead of silently testing at the wrong one; tracking is the second hypothesis source into the same verify/refine tail. Crate-private; results bit-identical on 1500 synthetic fields across plain, spurious, FOV-sweep, parity, hinted and aberration scenarios. ([#60](https://github.com/ssmichael1/tetra3rs/pull/60))
 - WCS refinement projects catalog stars with the tangent-plane basis at CRVAL (dot products, as Phase-D re-association already did) instead of decoding each matched star to RA/Dec and evaluating per-star trig every pass; `wcs_refine` 16.9 → 12.2 µs per solve on the profiler field (mean solve 50 → 41 µs), results unchanged within f64 rounding. ([#59](https://github.com/ssmichael1/tetra3rs/pull/59))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,7 +942,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tetra3"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "image",
  "numeris",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "tetra3-python"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "numeris",
  "numpy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = [
     "pattern-recognition",
 ]
 name = "tetra3"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Rust implementation of Tetra3: Fast and robust star plate solver"
 readme = "README.md"

--- a/docs/concepts/algorithm.md
+++ b/docs/concepts/algorithm.md
@@ -36,7 +36,7 @@ The `SolveResult` includes a `parity_flip` flag indicating whether this correcti
 
 ## Search Strategy
 
-The solver uses a breadth-first (brightest-first) search strategy. Brighter stars are more likely to be real detections (not noise), so trying patterns from the brightest centroids first maximizes the chance of an early match.
+The solver uses a breadth-first (brightest-first) search strategy. Brighter stars are more likely to be real detections (not noise), so trying patterns from the brightest centroids first maximizes the chance of an early match. Only the brightest `pattern_checking_stars` well-separated centroids (default 24) form patterns at all — the database stores patterns among each field's brightest stars, so those are the quads that can hit — which bounds a fruitless search at `C(24, 4) = 10,626` patterns per FOV value; fainter centroids still take part in verification.
 
 The search can be bounded by:
 

--- a/examples/profile_solve.rs
+++ b/examples/profile_solve.rs
@@ -140,12 +140,20 @@ fn main() {
         .and_then(|s| s.parse().ok())
         .unwrap_or(0.0);
 
+    // T3_PATTERN_STARS=N caps the pattern-forming centroids at the N
+    // brightest (SolveConfig::pattern_checking_stars; default when unset).
+    let pattern_checking_stars: u32 = std::env::var("T3_PATTERN_STARS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(SolveConfig::DEFAULT_PATTERN_CHECKING_STARS);
+
     let solve_config = SolveConfig {
         fov_max_error_rad: Some(2.0_f32.to_radians()),
         match_radius: 0.01,
         match_threshold: 1e-5,
         solve_timeout_ms: Some(10_000),
         match_max_error: None,
+        pattern_checking_stars,
         ..SolveConfig::new(fov_rad * (1.0 + fov_bias), image_width, image_width)
     };
 
@@ -155,6 +163,7 @@ fn main() {
     //                  full combination enumeration × full FOV sweep)
     //   T3_FOV_BIAS=x  bias the solver's FOV estimate by fraction x (see below)
     //   T3_MAX_CENTROIDS=N  keep only the N brightest true centroids per field
+    //   T3_PATTERN_STARS=N  cap pattern-forming centroids at the N brightest
     //                  (sparse-field scenario; fields with fewer than 4 are
     //                  regenerated as usual)
     let spurious: usize = std::env::var("T3_SPURIOUS")
@@ -167,7 +176,7 @@ fn main() {
         .and_then(|s| s.parse().ok());
     let half_w_px = half_fov / pixel_scale; // image half-extent in pixels
     eprintln!(
-        "Scenario: random_only={random_only}, spurious_per_field={spurious}, fov_bias={fov_bias}, max_centroids={max_centroids:?}"
+        "Scenario: random_only={random_only}, spurious_per_field={spurious}, fov_bias={fov_bias}, max_centroids={max_centroids:?}, pattern_stars={pattern_checking_stars}"
     );
 
     let mut rng = Rng(0x9E37_79B9_7F4A_7C15);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tetra3rs"
-version = "0.12.0"
+version = "0.13.0"
 description = "Fast star plate solver written in Rust"
 requires-python = ">=3.10"
 dependencies = ["numpy", "gaia-catalog<1.0"]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tetra3-python"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 publish = false
 

--- a/python/src/solver_database.rs
+++ b/python/src/solver_database.rs
@@ -136,7 +136,8 @@ impl PySolverDatabase {
     ///   ``match_radius``, ``match_threshold``, ``solve_timeout_ms``,
     ///   ``max_patterns_checked``,
     ///   ``observer_velocity_km_s``.
-    /// * **Lost-in-space only:** ``fov_max_error``, ``match_max_error``.
+    /// * **Lost-in-space only:** ``fov_max_error``, ``match_max_error``,
+    ///   ``pattern_checking_stars``.
     /// * **Tracking only** (ignored unless ``attitude_hint`` is set):
     ///   ``attitude_hint``, ``hint_uncertainty_*``, ``strict_hint``.
     ///
@@ -173,6 +174,12 @@ impl PySolverDatabase {
     ///         Composes with ``solve_timeout_ms`` — whichever trips first
     ///         ends the search. None = unbounded. Default: sized so the
     ///         5 s timeout normally trips first. Lost-in-space only.
+    ///     pattern_checking_stars: Number of brightest (well-separated)
+    ///         centroids the lost-in-space search forms 4-star patterns from;
+    ///         fainter centroids still take part in verification. Bounds a
+    ///         no-match search at C(N, 4) patterns per FOV value. Raise it
+    ///         when many of the brightest detections are not catalog stars.
+    ///         Must be >= 4. Default 24. Lost-in-space only.
     ///     match_max_error: Maximum edge-ratio error. None = use database value.
     ///         Values below the database's pattern quantization error are clamped up to it.
     ///     camera_model: A CameraModel specifying focal length, image dimensions,
@@ -228,6 +235,7 @@ impl PySolverDatabase {
         match_threshold = 1e-5,
         solve_timeout_ms = Some(5000),
         max_patterns_checked = Some(SolveConfig::DEFAULT_MAX_PATTERNS_CHECKED),
+        pattern_checking_stars = SolveConfig::DEFAULT_PATTERN_CHECKING_STARS,
         match_max_error = None,
         camera_model = None,
         observer_velocity_km_s = None,
@@ -252,6 +260,7 @@ impl PySolverDatabase {
         match_threshold: f64,
         solve_timeout_ms: Option<u64>,
         max_patterns_checked: Option<u64>,
+        pattern_checking_stars: u32,
         match_max_error: Option<f32>,
         camera_model: Option<PyCameraModel>,
         observer_velocity_km_s: Option<[f64; 3]>,
@@ -329,6 +338,7 @@ impl PySolverDatabase {
             match_threshold,
             solve_timeout_ms,
             max_patterns_checked,
+            pattern_checking_stars,
             match_max_error,
             camera_model: cam,
             observer_velocity_km_s,

--- a/python/tests/test_solve.py
+++ b/python/tests/test_solve.py
@@ -247,6 +247,52 @@ class TestSolveFromCentroids:
         assert not result
         assert result.status == "invalid_config"
 
+    def test_pattern_checking_stars_caps_search(self, skyview_db):
+        """A clean field still solves when only the brightest few centroids
+        may form patterns, and the cap bounds a no-match search."""
+        ra, dec = 83.0, -1.0
+        fov_deg = 10.0
+        image_size = 2048
+        f_px = image_size / (2.0 * math.tan(math.radians(fov_deg / 2.0)))
+        stars = skyview_db.cone_search(ra, dec, fov_deg)
+        centroids = project_stars_tan(stars[:50], ra, dec, f_px, image_size)
+        result = skyview_db.solve_from_centroids(
+            centroids,
+            fov_estimate_deg=fov_deg,
+            image_width=image_size,
+            image_height=image_size,
+            pattern_checking_stars=8,
+        )
+        assert result, f"solve failed: {result}"
+        assert result.num_matches >= 10
+
+        rng = np.random.default_rng(11)
+        random_field = rng.uniform(-900.0, 900.0, size=(40, 2))
+        result = skyview_db.solve_from_centroids(
+            random_field,
+            fov_estimate_deg=fov_deg,
+            image_width=image_size,
+            image_height=image_size,
+            pattern_checking_stars=6,
+            max_patterns_checked=None,
+        )
+        assert not result
+        assert result.status == "no_match"
+
+    def test_pattern_checking_stars_below_four_is_invalid_config(self, skyview_db):
+        centroids = np.array(
+            [[40.0 * i - 100.0, 25.0 * i - 60.0] for i in range(6)], dtype=np.float64
+        )
+        result = skyview_db.solve_from_centroids(
+            centroids,
+            fov_estimate_deg=10.0,
+            image_width=2048,
+            image_height=2048,
+            pattern_checking_stars=3,
+        )
+        assert not result
+        assert result.status == "invalid_config"
+
     def test_solve_with_numpy_array_3col(self, skyview_db):
         """Verify centroids can be passed as Nx3 numpy array (x, y, brightness)."""
         ra, dec = 83.0, -1.0

--- a/python/tetra3rs/__init__.pyi
+++ b/python/tetra3rs/__init__.pyi
@@ -652,6 +652,7 @@ class SolverDatabase:
         match_threshold: float = 1e-5,
         solve_timeout_ms: Optional[int] = 5000,
         max_patterns_checked: Optional[int] = 10_000_000,
+        pattern_checking_stars: int = 24,
         match_max_error: Optional[float] = None,
         camera_model: Optional[CameraModel] = None,
         observer_velocity_km_s: Optional[list[float]] = None,
@@ -673,7 +674,8 @@ class SolverDatabase:
           ``match_radius``, ``match_threshold``, ``solve_timeout_ms``,
           ``max_patterns_checked``,
           ``observer_velocity_km_s``.
-        * **Lost-in-space only:** ``fov_max_error_*``, ``match_max_error``.
+        * **Lost-in-space only:** ``fov_max_error_*``, ``match_max_error``,
+          ``pattern_checking_stars``.
         * **Tracking only** (ignored unless ``attitude_hint`` is set):
           ``attitude_hint``, ``hint_uncertainty_*``, ``strict_hint``.
 
@@ -710,6 +712,12 @@ class SolverDatabase:
                 than wall time, so the outcome is the same on every machine;
                 composes with ``solve_timeout_ms`` (whichever trips first).
                 None = unbounded. Lost-in-space only.
+            pattern_checking_stars: Number of brightest (well-separated)
+                centroids the lost-in-space search forms 4-star patterns
+                from; fainter centroids still take part in verification.
+                Bounds a no-match search at C(N, 4) patterns per FOV value.
+                Raise it when many of the brightest detections are not
+                catalog stars. Must be >= 4. Lost-in-space only.
             match_max_error: Maximum edge-ratio error. None = use database value.
                 Values below the database's pattern quantization error are clamped up to it.
                 Lost-in-space only — tracking does not use the pattern hash.

--- a/src/solver/database.rs
+++ b/src/solver/database.rs
@@ -323,7 +323,12 @@ impl SolverDatabase {
             );
         }
 
-        let pattern_list: Vec<[u32; PATTERN_SIZE]> = pattern_set.into_iter().collect();
+        // Sort so the table layout is a pure function of the input: HashSet
+        // iteration order varies per process, which made hash-chain order —
+        // and therefore the candidate order / `Solution.prob` divisor of a
+        // solve — differ between databases generated from identical inputs.
+        let mut pattern_list: Vec<[u32; PATTERN_SIZE]> = pattern_set.into_iter().collect();
+        pattern_list.sort_unstable();
         info!("Total unique patterns: {}", pattern_list.len());
 
         // ── Build hash table ──

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -479,6 +479,22 @@ pub struct SolveConfig {
     /// whichever trips first ends the search. *Lost-in-space only* — tracking
     /// tests a single hinted candidate and never enumerates patterns.
     pub max_patterns_checked: Option<u64>,
+    /// Number of brightest pattern-eligible centroids the lost-in-space
+    /// search forms 4-star patterns from. Default
+    /// [`SolveConfig::DEFAULT_PATTERN_CHECKING_STARS`].
+    ///
+    /// After cluster-buster thinning, only the brightest `N` surviving
+    /// centroids are combined into image patterns (all `C(N, 4)` of them,
+    /// brightest-first); fainter centroids still take part in verification.
+    /// This mirrors database generation, which stores patterns among the
+    /// brightest well-separated catalog stars of each field, so the quads
+    /// most likely to be in the table are exactly the bright ones — and it
+    /// bounds a no-match search at `C(N, 4)` patterns per FOV value instead
+    /// of `C(all, 4)`. Raise it for fields where many of the brightest
+    /// detections are not catalog stars (hot pixels, satellites, planets);
+    /// `u32::MAX` restores the unbounded search. Must be at least 4
+    /// (`validate()`). *Lost-in-space only.*
+    pub pattern_checking_stars: u32,
 
     // ── Tracking (ignored unless `attitude_hint` is set) ──
     /// Optional attitude hint for tracking-mode solving.
@@ -540,6 +556,7 @@ impl Default for SolveConfig {
             solve_timeout_ms: Some(5000),
             match_max_error: None,
             max_patterns_checked: Some(Self::DEFAULT_MAX_PATTERNS_CHECKED),
+            pattern_checking_stars: Self::DEFAULT_PATTERN_CHECKING_STARS,
             camera_model: CameraModel {
                 focal_length_px: 1.0,
                 image_width: 0,
@@ -573,6 +590,9 @@ impl SolveConfig {
     /// default database is ≲ C(40, 4) ≈ 91 k patterns; the budget matters
     /// for dense databases and long FOV sweeps.
     pub const DEFAULT_MAX_PATTERNS_CHECKED: u64 = 10_000_000;
+
+    /// Default [`pattern_checking_stars`](Self::pattern_checking_stars).
+    pub const DEFAULT_PATTERN_CHECKING_STARS: u32 = 24;
 
     /// Create a solve configuration with the given FOV estimate (radians) and
     /// image dimensions, using a simple pinhole camera model (no distortion,
@@ -644,6 +664,8 @@ impl SolveConfig {
     ///   positive.
     /// - [`max_patterns_checked`](Self::max_patterns_checked), if set, is
     ///   positive (`Some(0)` would search nothing; use `None` for unbounded).
+    /// - [`pattern_checking_stars`](Self::pattern_checking_stars) is at
+    ///   least 4 (fewer can never form a pattern).
     /// - [`observer_velocity_km_s`](Self::observer_velocity_km_s), if set,
     ///   has finite components.
     /// - [`hint_uncertainty_rad`](Self::hint_uncertainty_rad) is finite and
@@ -683,6 +705,13 @@ impl SolveConfig {
             return Err(InvalidInput(
                 "max_patterns_checked must be > 0 (None = unbounded)".into(),
             ));
+        }
+        if (self.pattern_checking_stars as usize) < pattern::PATTERN_SIZE {
+            return Err(InvalidInput(format!(
+                "pattern_checking_stars must be >= {} (a 4-star pattern needs 4 stars), got {}",
+                pattern::PATTERN_SIZE,
+                self.pattern_checking_stars
+            )));
         }
         if let Some(v) = self.observer_velocity_km_s {
             if !v.iter().all(|c| c.is_finite()) {
@@ -870,6 +899,7 @@ mod tests {
         bad(|c| c.fov_max_error_rad = Some(f32::INFINITY));
         bad(|c| c.match_max_error = Some(f32::NAN));
         bad(|c| c.max_patterns_checked = Some(0)); // would search nothing
+        bad(|c| c.pattern_checking_stars = 3); // can never form a pattern
         bad(|c| c.observer_velocity_km_s = Some([f64::NAN, 0.0, 0.0]));
         bad(|c| {
             c.attitude_hint = Some(Quaternion::identity());

--- a/src/solver/pattern_search.rs
+++ b/src/solver/pattern_search.rs
@@ -229,14 +229,22 @@ impl<'a> PatternSearch<'a> {
             }
         }
 
-        let pattern_centroid_inds: Vec<usize> = (0..num_centroids)
+        let mut pattern_centroid_inds: Vec<usize> = (0..num_centroids)
             .filter(|&i| keep_for_patterns[i])
             .collect();
+        let num_after_thinning = pattern_centroid_inds.len();
+        // Only the brightest `pattern_checking_stars` survivors form
+        // patterns (see `SolveConfig::pattern_checking_stars`): the table
+        // holds patterns among each field's brightest well-separated stars,
+        // so bright quads are the ones that can hit, and the cap bounds a
+        // no-match search at C(N, 4) per FOV value. `pattern_centroid_inds`
+        // is ascending in brightness rank, so truncation keeps the brightest.
+        pattern_centroid_inds.truncate(config.pattern_checking_stars as usize);
         let num_pattern_centroids = pattern_centroid_inds.len();
 
         debug!(
-            "Centroids: {} total, {} for patterns after cluster busting",
-            num_centroids, num_pattern_centroids
+            "Centroids: {} total, {} for patterns after cluster busting, {} after the brightness cap",
+            num_centroids, num_after_thinning, num_pattern_centroids
         );
 
         if num_pattern_centroids < PATTERN_SIZE {


### PR DESCRIPTION
PR 2 of the September solver review stack (originally stacked on #60 → #59).

## What

**`SolveConfig::pattern_checking_stars`** (Python `pattern_checking_stars=`, default **24**). After cluster-buster thinning, only the brightest N surviving centroids are combined into 4-star image patterns; fainter centroids still take part in verification. The database stores only `patterns_per_lattice_field` (50) patterns per lattice field, breadth-first among the brightest well-separated stars — quads among roughly the 9 brightest — so bright image quads are the only ones that can hit. The cap bounds a fruitless lost-in-space search at C(N, 4) patterns per FOV value, independent of how many centroids survive thinning. `u32::MAX` restores the unbounded search; < 4 fails `validate()`. Mirrors upstream tetra3's `pattern_checking_stars` (default 8 there).

**Measured effect** (profiler, 10° FOV, default database; a no-match field is all-random centroids). Thinning at the verification separation already limits survivors to ~30–40 per pass, so the unbounded search never approached the timeout — the gain is a 2–8× cut on the failure path only:

| no-match detections | combos/pass unbounded | combos/pass cap 24 | mean time unbounded | cap 24 |
|---|---|---|---|---|
| 30 | ~same | ~same | 1.81 ms | 1.78 ms |
| 120 | 19.6k | 10.6k | 16.9 ms | 8.8 ms |
| 400 | 48k | 10.6k | 40 ms | 9 ms |
| 1500 | 79k | 10.6k | 69 ms | 9 ms |

Successful solves are untouched: enumeration is breadth-first by brightness, so the first hit is the same quad (plain + 30 spurious: 8.9 combos/solve and 300/300 either way).

Also in this PR:
- **Deterministic database generation** (separate commit): the pattern list is sorted before building the hash table. `HashSet` iteration order varied per process, changing chain order and the candidates-tested divisor of `Solution.prob` between otherwise identical databases (the side finding from #60). Two generations now produce byte-identical solve dumps.
- Profiler knob `T3_PATTERN_STARS=N`; Python wrapper, stubs, docs; two Python tests.
- **Version 0.13.0** in `Cargo.toml` / `pyproject.toml` / `python/Cargo.toml` — a new field on an exhaustive struct is a breaking change under 0.x, and CI's cargo-semver-checks compares against the published crate. (This bump also clears the semver failure #59 showed for the removed profile-gated `WCS_RADEC` bucket constant.)

## Choosing the default

| cap | plain /1000 | spur20 /300 | spur40 /300 | sparse6 /300 | SkyView (real, 10 fields) |
|---|---|---|---|---|---|
| 8 | 1000 | 294 | 269 | 232 | — |
| 12 | 1000 | 300 | 297 | 232 | 7/10 |
| 16 | 1000 | 300 | 298 | 232 | 9/10 |
| 20 | — | — | — | — | 10/10 |
| **24** | 1000 | 300 | 298 | 232 | 10/10 |
| ∞ | 1000 | 300 | 298 | 232 | 10/10 |

Real images need at least 20: some of the brightest detections are not catalog pattern stars (blends, saturation, extended objects). 24 gives margin, though the sample is small (10 SkyView + TESS). Note the synthetic spurious scenarios don't stress this: spurious centroids get brightness 0–5 versus 10 − mag for real stars, so bright fakes never displace bright stars in the ordering.

## Verification

- 1500-field golden dump (plain, 20/30 spurious, FOV sweep, parity, hinted, aberration): identical to the unbounded baseline at cap 24 (cap 12 lost 2 fields in the 30-spurious scenario).
- `cargo clippy --all-targets --all-features -D warnings` clean; unit, `integration_test`, `skyview_solve_test` (10/10), `tess_solve_test` (incl. multi-image calibration) pass.
- Python: rebuilt extension, 100/100 tests pass (2 new: cap solves a clean field and bounds a random one; < 4 → `invalid_config`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZ3H9bdqVtf65gw8XbSRko
https://claude.ai/code/session_0158ebnyHMnaBWJhbr1TZzUF
