### PR TITLE
release: 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Only recent releases are listed. Older entries are in this file's git history (`git show vX.Y.Z:CHANGELOG.md`). Full detail for each change lives in the linked PR.
 
-## Unreleased
+## 0.13.0 - 2026-09-04
 
 **Upgrading from 0.12:** `SolveConfig` gains `pattern_checking_stars` (Rust struct literals need the field or `..Default::default()`); pickled Python `SolveResult`s from earlier versions do not load; databases saved by 0.12 and earlier still load, but were built with cone queries that missed stars near the poles and on wide fields — regenerate them with `generate_from_gaia` to get full coverage; verification is now a likelihood ratio, so `prob` values differ from 0.12 while `match_threshold` keeps its meaning as a per-solve false-accept budget.
 


### PR DESCRIPTION
Dates the changelog entry for 0.13.0. Version bumps landed in #61; the release contents are the Unreleased section of CHANGELOG.md (PRs #59–#67).

After merge: tag `v0.13.0` on the merge commit (PyPI wheels via publish.yml) and `cargo publish -p tetra3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158ebnyHMnaBWJhbr1TZzUF